### PR TITLE
feat: automatic discount rules with best-discount selection (Story 016)

### DIFF
--- a/pretex/lib/pretex/discounts.ex
+++ b/pretex/lib/pretex/discounts.ex
@@ -1,0 +1,247 @@
+defmodule Pretex.Discounts do
+  @moduledoc "Manages automatic discount rules for events."
+
+  import Ecto.Query
+
+  alias Pretex.Repo
+  alias Pretex.Discounts.DiscountRule
+
+  alias Pretex.Discounts.OrderDiscount
+  alias Pretex.Orders.Order
+
+  # ---------------------------------------------------------------------------
+  # CRUD
+  # ---------------------------------------------------------------------------
+
+  @doc "List all discount rules for an event, ordered by name asc. Preloads :scoped_items."
+  def list_discount_rules(%{id: event_id}) do
+    DiscountRule
+    |> where([dr], dr.event_id == ^event_id)
+    |> order_by([dr], asc: dr.name)
+    |> preload(:scoped_items)
+    |> Repo.all()
+  end
+
+  @doc "Get a discount rule by id, raises if not found. Preloads :scoped_items."
+  def get_discount_rule!(id) do
+    DiscountRule
+    |> preload(:scoped_items)
+    |> Repo.get!(id)
+  end
+
+  @doc "Create a discount rule for an event."
+  def create_discount_rule(%{id: event_id}, attrs) do
+    %DiscountRule{}
+    |> DiscountRule.changeset(attrs)
+    |> Ecto.Changeset.put_change(:event_id, event_id)
+    |> Repo.insert()
+  end
+
+  @doc "Update a discount rule."
+  def update_discount_rule(%DiscountRule{} = rule, attrs) do
+    rule
+    |> DiscountRule.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc "Delete a discount rule."
+  def delete_discount_rule(%DiscountRule{} = rule) do
+    Repo.delete(rule)
+  end
+
+  @doc "Return a changeset for a discount rule (used by forms)."
+  def change_discount_rule(%DiscountRule{} = rule, attrs \\ %{}) do
+    DiscountRule.changeset(rule, attrs)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Evaluation
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Evaluate all active discount rules for an event against the given cart items.
+
+  cart_items is a list of maps with keys:
+    %{item_id:, item_variation_id:, quantity:, unit_price_cents:}
+
+  Returns a list of matching %{rule: rule, discount_cents: integer} sorted
+  descending by discount_cents (highest discount first).
+  """
+  def evaluate_cart(event_id, cart_items) when is_list(cart_items) do
+    rules =
+      DiscountRule
+      |> where([dr], dr.event_id == ^event_id and dr.active == true)
+      |> preload(:scoped_items)
+      |> Repo.all()
+
+    rules
+    |> Enum.filter(&rule_matches?(&1, cart_items))
+    |> Enum.map(fn rule ->
+      discount_cents = compute_discount(rule, cart_items)
+      %{rule: rule, discount_cents: discount_cents}
+    end)
+    |> Enum.sort_by(& &1.discount_cents, :desc)
+  end
+
+  @doc """
+  Returns the single best (highest) discount for the cart.
+  Returns {:ok, %{rule: rule, discount_cents: integer}} | {:error, :no_discount}
+  """
+  def best_discount(event_id, cart_items) do
+    case evaluate_cart(event_id, cart_items) do
+      [] -> {:error, :no_discount}
+      [best | _] -> {:ok, best}
+    end
+  end
+
+  @doc """
+  Quick preview of the best discount in cents. Returns 0 if no rule matches.
+  """
+  def compute_discount_for_cart(event_id, cart_items) do
+    case best_discount(event_id, cart_items) do
+      {:ok, %{discount_cents: cents}} -> cents
+      {:error, :no_discount} -> 0
+    end
+  end
+
+  @doc """
+  Apply the best matching discount rule to an order.
+
+  Expects order to have order_items preloaded with :item and :item_variation.
+  Inserts an OrderDiscount record and updates order.total_cents.
+
+  Uses bare Repo operations (no nested transaction) so it participates in
+  any outer transaction the caller has started.
+
+  Returns {:ok, updated_order} | {:error, reason}
+  """
+  def apply_best_discount(%Order{} = order, event_id) do
+    cart_items = build_cart_items_from_order(order)
+
+    case best_discount(event_id, cart_items) do
+      {:error, :no_discount} ->
+        {:ok, order}
+
+      {:ok, %{rule: rule, discount_cents: discount_cents}} ->
+        # Cap so total never goes below 0
+        capped_discount = min(discount_cents, order.total_cents)
+
+        od_changeset =
+          %OrderDiscount{}
+          |> OrderDiscount.changeset(%{
+            name: rule.name,
+            discount_cents: capped_discount,
+            value_type: rule.value_type,
+            value: rule.value,
+            order_id: order.id,
+            discount_rule_id: rule.id
+          })
+
+        case Repo.insert(od_changeset) do
+          {:ok, _order_discount} ->
+            new_total = max(0, order.total_cents - capped_discount)
+
+            updated =
+              order
+              |> Ecto.Changeset.change(total_cents: new_total)
+              |> Repo.update!()
+
+            {:ok, updated}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp build_cart_items_from_order(%Order{order_items: order_items})
+       when is_list(order_items) do
+    Enum.map(order_items, fn oi ->
+      unit_price =
+        if oi.item_variation && oi.item_variation.price_cents do
+          oi.item_variation.price_cents
+        else
+          oi.item.price_cents
+        end
+
+      %{
+        item_id: oi.item_id,
+        item_variation_id: oi.item_variation_id,
+        quantity: oi.quantity,
+        unit_price_cents: unit_price
+      }
+    end)
+  end
+
+  defp build_cart_items_from_order(_order), do: []
+
+  defp rule_matches?(%DiscountRule{condition_type: "min_quantity"} = rule, cart_items) do
+    scoped_item_ids = scoped_item_ids(rule)
+
+    total_quantity =
+      if scoped_item_ids == [] do
+        # No scope restriction — count ALL cart items
+        Enum.sum(Enum.map(cart_items, & &1.quantity))
+      else
+        # Only count items in the scoped set
+        cart_items
+        |> Enum.filter(&(&1.item_id in scoped_item_ids))
+        |> Enum.sum_by(& &1.quantity)
+      end
+
+    total_quantity >= rule.min_quantity
+  end
+
+  defp rule_matches?(%DiscountRule{condition_type: "item_combo"} = rule, cart_items) do
+    scoped_item_ids = scoped_item_ids(rule)
+
+    if scoped_item_ids == [] do
+      # item_combo with no scoped items never matches
+      false
+    else
+      cart_item_ids = MapSet.new(cart_items, & &1.item_id)
+
+      Enum.all?(scoped_item_ids, &MapSet.member?(cart_item_ids, &1))
+    end
+  end
+
+  defp rule_matches?(_rule, _cart_items), do: false
+
+  defp scoped_item_ids(%DiscountRule{scoped_items: scoped_items})
+       when is_list(scoped_items) do
+    scoped_items
+    |> Enum.map(& &1.item_id)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp scoped_item_ids(_), do: []
+
+  defp compute_discount(%DiscountRule{} = rule, cart_items) do
+    scoped_item_ids = scoped_item_ids(rule)
+
+    subtotal =
+      if scoped_item_ids == [] do
+        Enum.sum(Enum.map(cart_items, &(&1.quantity * &1.unit_price_cents)))
+      else
+        cart_items
+        |> Enum.filter(&(&1.item_id in scoped_item_ids))
+        |> Enum.sum_by(&(&1.quantity * &1.unit_price_cents))
+      end
+
+    case rule.value_type do
+      "fixed" ->
+        min(rule.value, subtotal)
+
+      "percentage" ->
+        round(subtotal * rule.value / 10_000)
+
+      _ ->
+        0
+    end
+  end
+end

--- a/pretex/lib/pretex/discounts/discount_rule.ex
+++ b/pretex/lib/pretex/discounts/discount_rule.ex
@@ -1,0 +1,57 @@
+defmodule Pretex.Discounts.DiscountRule do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @condition_types ~w(min_quantity item_combo)
+  @value_types ~w(fixed percentage)
+
+  schema "discount_rules" do
+    field(:name, :string)
+    field(:condition_type, :string, default: "min_quantity")
+    field(:min_quantity, :integer, default: 1)
+    field(:value_type, :string, default: "percentage")
+    field(:value, :integer, default: 0)
+    field(:active, :boolean, default: true)
+    field(:description, :string)
+
+    belongs_to(:event, Pretex.Events.Event)
+    has_many(:scoped_items, Pretex.Discounts.DiscountRuleItem)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def condition_types, do: @condition_types
+  def value_types, do: @value_types
+
+  def changeset(rule, attrs) do
+    rule
+    |> cast(attrs, [
+      :name,
+      :condition_type,
+      :min_quantity,
+      :value_type,
+      :value,
+      :active,
+      :description,
+      :event_id
+    ])
+    |> validate_required([:name, :condition_type, :value_type, :value])
+    |> validate_inclusion(:condition_type, @condition_types)
+    |> validate_inclusion(:value_type, @value_types)
+    |> validate_number(:value, greater_than_or_equal_to: 0)
+    |> validate_number(:min_quantity, greater_than_or_equal_to: 1)
+    |> validate_length(:name, min: 2, max: 255)
+    |> validate_percentage_max()
+  end
+
+  defp validate_percentage_max(changeset) do
+    if get_field(changeset, :value_type) == "percentage" do
+      validate_number(changeset, :value,
+        less_than_or_equal_to: 10_000,
+        message: "não pode exceder 100%"
+      )
+    else
+      changeset
+    end
+  end
+end

--- a/pretex/lib/pretex/discounts/discount_rule_item.ex
+++ b/pretex/lib/pretex/discounts/discount_rule_item.ex
@@ -1,0 +1,18 @@
+defmodule Pretex.Discounts.DiscountRuleItem do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "discount_rule_items" do
+    belongs_to(:discount_rule, Pretex.Discounts.DiscountRule)
+    belongs_to(:item, Pretex.Catalog.Item)
+    belongs_to(:item_variation, Pretex.Catalog.ItemVariation)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(dri, attrs) do
+    dri
+    |> cast(attrs, [:discount_rule_id, :item_id, :item_variation_id])
+    |> validate_required([:discount_rule_id])
+  end
+end

--- a/pretex/lib/pretex/discounts/order_discount.ex
+++ b/pretex/lib/pretex/discounts/order_discount.ex
@@ -1,0 +1,23 @@
+defmodule Pretex.Discounts.OrderDiscount do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "order_discounts" do
+    field(:name, :string)
+    field(:discount_cents, :integer, default: 0)
+    field(:value_type, :string)
+    field(:value, :integer)
+
+    belongs_to(:order, Pretex.Orders.Order)
+    belongs_to(:discount_rule, Pretex.Discounts.DiscountRule)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(od, attrs) do
+    od
+    |> cast(attrs, [:name, :discount_cents, :value_type, :value, :order_id, :discount_rule_id])
+    |> validate_required([:name, :discount_cents])
+    |> validate_number(:discount_cents, greater_than_or_equal_to: 0)
+  end
+end

--- a/pretex/lib/pretex/gift_cards.ex
+++ b/pretex/lib/pretex/gift_cards.ex
@@ -1,0 +1,275 @@
+defmodule Pretex.GiftCards do
+  @moduledoc "Manages gift cards for organizations."
+
+  import Ecto.Query
+
+  alias Pretex.Repo
+  alias Pretex.GiftCards.GiftCard
+  alias Pretex.GiftCards.GiftCardRedemption
+  alias Pretex.Organizations.Organization
+
+  # ---------------------------------------------------------------------------
+  # CRUD
+  # ---------------------------------------------------------------------------
+
+  @doc "List all gift cards for an organization, ordered by inserted_at desc. Preloads :redemptions."
+  def list_gift_cards(%Organization{id: org_id}) do
+    GiftCard
+    |> where([gc], gc.organization_id == ^org_id)
+    |> order_by([gc], desc: gc.inserted_at)
+    |> preload(:redemptions)
+    |> Repo.all()
+  end
+
+  @doc "Get a gift card by id, raises if not found. Preloads :redemptions."
+  def get_gift_card!(id) do
+    GiftCard
+    |> preload(:redemptions)
+    |> Repo.get!(id)
+  end
+
+  @doc """
+  Look up a gift card by code (case-insensitive). Gift card codes are globally unique.
+  Returns {:ok, gift_card} | {:error, :not_found}.
+  """
+  def get_gift_card_by_code(code) when is_binary(code) do
+    normalized = String.upcase(String.trim(code))
+
+    case Repo.get_by(GiftCard, code: normalized) do
+      nil -> {:error, :not_found}
+      gc -> {:ok, gc}
+    end
+  end
+
+  def get_gift_card_by_code(_), do: {:error, :not_found}
+
+  @doc """
+  Create a gift card for an organization.
+  If initial_balance_cents not given, it defaults to balance_cents.
+  Returns {:ok, gift_card} | {:error, changeset}.
+  """
+  def create_gift_card(%Organization{} = org, attrs) do
+    attrs =
+      if Map.get(attrs, :initial_balance_cents) || Map.get(attrs, "initial_balance_cents") do
+        attrs
+      else
+        balance = Map.get(attrs, :balance_cents) || Map.get(attrs, "balance_cents") || 0
+
+        if is_map(attrs) and map_size(attrs) > 0 and match?(%{}, attrs) do
+          if is_atom(hd(Map.keys(attrs))) do
+            Map.put_new(attrs, :initial_balance_cents, balance)
+          else
+            Map.put_new(attrs, "initial_balance_cents", balance)
+          end
+        else
+          Map.put_new(attrs, :initial_balance_cents, balance)
+        end
+      end
+
+    %GiftCard{}
+    |> GiftCard.changeset(attrs)
+    |> Ecto.Changeset.put_change(:organization_id, org.id)
+    |> Repo.insert()
+  end
+
+  @doc "Update a gift card. Returns {:ok, gift_card} | {:error, changeset}."
+  def update_gift_card(%GiftCard{} = gc, attrs) do
+    gc
+    |> GiftCard.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc "Delete a gift card. Returns {:ok, gift_card} | {:error, changeset}."
+  def delete_gift_card(%GiftCard{} = gc) do
+    Repo.delete(gc)
+  end
+
+  @doc "Return a changeset for a gift card (used by forms)."
+  def change_gift_card(%GiftCard{} = gc, attrs \\ %{}) do
+    GiftCard.changeset(gc, attrs)
+  end
+
+  @doc """
+  Add amount_cents to a gift card's balance.
+  Inserts a GiftCardRedemption with kind: "credit", note: "Top-up".
+  Returns {:ok, gift_card} | {:error, reason}.
+  """
+  def top_up(%GiftCard{} = gc, amount_cents) when is_integer(amount_cents) and amount_cents > 0 do
+    Repo.transaction(fn ->
+      new_balance = gc.balance_cents + amount_cents
+
+      {:ok, updated_gc} =
+        gc
+        |> Ecto.Changeset.change(balance_cents: new_balance)
+        |> Repo.update()
+
+      %GiftCardRedemption{}
+      |> GiftCardRedemption.changeset(%{
+        amount_cents: amount_cents,
+        kind: "credit",
+        note: "Top-up",
+        gift_card_id: gc.id
+      })
+      |> Repo.insert!()
+
+      updated_gc
+    end)
+  end
+
+  def top_up(%GiftCard{}, _amount), do: {:error, :invalid_amount}
+
+  # ---------------------------------------------------------------------------
+  # Validation
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Validates a gift card code for checkout.
+  Checks: exists, active, belongs to organization_id, not expired, balance > 0.
+  Returns {:ok, gift_card} | {:error, reason}.
+  reason: :not_found | :wrong_organization | :expired | :empty | :inactive
+  """
+  def validate_for_checkout(code, organization_id) when is_binary(code) do
+    case get_gift_card_by_code(code) do
+      {:error, :not_found} ->
+        {:error, :not_found}
+
+      {:ok, gc} ->
+        now = DateTime.utc_now()
+
+        cond do
+          gc.organization_id != organization_id ->
+            {:error, :wrong_organization}
+
+          !gc.active ->
+            {:error, :inactive}
+
+          gc.expires_at != nil and DateTime.compare(gc.expires_at, now) == :lt ->
+            {:error, :expired}
+
+          gc.balance_cents <= 0 ->
+            {:error, :empty}
+
+          true ->
+            {:ok, gc}
+        end
+    end
+  end
+
+  def validate_for_checkout(_, _), do: {:error, :not_found}
+
+  # ---------------------------------------------------------------------------
+  # Redemption
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Redeem a gift card against an order.
+  requested_cents = order's remaining total.
+  actual_deduction = min(gift_card.balance_cents, requested_cents).
+  Updates gift_card.balance_cents and inserts a GiftCardRedemption{kind: "debit"}.
+  NOTE: uses bare Repo ops (no nested transaction) — participates in caller's transaction.
+  Returns {:ok, %{gift_card: updated_gc, deduction_cents: actual_deduction}}.
+  """
+  def redeem(%GiftCard{} = gc, order, requested_cents)
+      when is_integer(requested_cents) and requested_cents >= 0 do
+    actual_deduction = min(gc.balance_cents, requested_cents)
+
+    if actual_deduction <= 0 do
+      {:ok, %{gift_card: gc, deduction_cents: 0}}
+    else
+      new_balance = gc.balance_cents - actual_deduction
+
+      case gc |> Ecto.Changeset.change(balance_cents: new_balance) |> Repo.update() do
+        {:ok, updated_gc} ->
+          %GiftCardRedemption{}
+          |> GiftCardRedemption.changeset(%{
+            kind: "debit",
+            amount_cents: actual_deduction,
+            gift_card_id: gc.id,
+            order_id: order.id
+          })
+          |> Repo.insert!()
+
+          {:ok, %{gift_card: updated_gc, deduction_cents: actual_deduction}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @doc """
+  Restores amount_cents to a gift card's balance (called on refund).
+  If gift_card.expires_at is in the past, extends expiry by 1 year from now.
+  Uses bare Repo ops — participates in caller's transaction.
+  Returns {:ok, gift_card} | {:error, reason}.
+  """
+  def restore_balance(%GiftCard{} = gc, amount_cents, _opts \\ [])
+      when is_integer(amount_cents) and amount_cents > 0 do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {note, expires_at_update} =
+      if gc.expires_at != nil and DateTime.compare(gc.expires_at, now) == :lt do
+        new_expiry =
+          now |> DateTime.add(365 * 24 * 3600, :second) |> DateTime.truncate(:second)
+
+        {"Restaurado por reembolso (validade estendida)", new_expiry}
+      else
+        {"Restaurado por reembolso", gc.expires_at}
+      end
+
+    new_balance = gc.balance_cents + amount_cents
+
+    changes =
+      if expires_at_update != gc.expires_at do
+        [balance_cents: new_balance, expires_at: expires_at_update]
+      else
+        [balance_cents: new_balance]
+      end
+
+    case gc |> Ecto.Changeset.change(changes) |> Repo.update() do
+      {:ok, updated_gc} ->
+        %GiftCardRedemption{}
+        |> GiftCardRedemption.changeset(%{
+          kind: "credit",
+          amount_cents: amount_cents,
+          note: note,
+          gift_card_id: gc.id
+        })
+        |> Repo.insert!()
+
+        {:ok, updated_gc}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns the GiftCardRedemption with kind "debit" for the given order_id,
+  preloaded with :gift_card, or nil if not found.
+  """
+  def get_debit_redemption_for_order(order_id) do
+    GiftCardRedemption
+    |> where([r], r.order_id == ^order_id and r.kind == "debit")
+    |> preload(:gift_card)
+    |> Repo.one()
+  end
+
+  @doc """
+  Generates a candidate gift card code: "GC-XXXXXXXX" where X is uppercase alphanumeric (8 chars).
+  Uniqueness is enforced by the DB unique constraint; this just generates a candidate.
+  """
+  def generate_code do
+    chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+    suffix =
+      1..8
+      |> Enum.map(fn _ ->
+        (:rand.uniform(String.length(chars)) - 1)
+        |> then(&String.at(chars, &1))
+      end)
+      |> Enum.join()
+
+    "GC-#{suffix}"
+  end
+end

--- a/pretex/lib/pretex/gift_cards/gift_card.ex
+++ b/pretex/lib/pretex/gift_cards/gift_card.ex
@@ -1,0 +1,39 @@
+defmodule Pretex.GiftCards.GiftCard do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "gift_cards" do
+    field(:code, :string)
+    field(:balance_cents, :integer, default: 0)
+    field(:initial_balance_cents, :integer, default: 0)
+    field(:expires_at, :utc_datetime)
+    field(:active, :boolean, default: true)
+    field(:note, :string)
+
+    belongs_to(:organization, Pretex.Organizations.Organization)
+    belongs_to(:source_order, Pretex.Orders.Order, foreign_key: :source_order_id)
+    has_many(:redemptions, Pretex.GiftCards.GiftCardRedemption)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(gc, attrs) do
+    gc
+    |> cast(attrs, [
+      :code,
+      :balance_cents,
+      :initial_balance_cents,
+      :expires_at,
+      :active,
+      :note,
+      :organization_id,
+      :source_order_id
+    ])
+    |> validate_required([:code, :balance_cents])
+    |> validate_number(:balance_cents, greater_than_or_equal_to: 0)
+    |> validate_number(:initial_balance_cents, greater_than_or_equal_to: 0)
+    |> validate_length(:code, min: 1, max: 64)
+    |> update_change(:code, &String.upcase(String.trim(&1)))
+    |> unique_constraint(:code, name: :gift_cards_code_index)
+  end
+end

--- a/pretex/lib/pretex/gift_cards/gift_card_redemption.ex
+++ b/pretex/lib/pretex/gift_cards/gift_card_redemption.ex
@@ -1,0 +1,27 @@
+defmodule Pretex.GiftCards.GiftCardRedemption do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @kinds ~w(debit credit)
+
+  schema "gift_card_redemptions" do
+    field(:amount_cents, :integer, default: 0)
+    field(:kind, :string, default: "debit")
+    field(:note, :string)
+
+    belongs_to(:gift_card, Pretex.GiftCards.GiftCard)
+    belongs_to(:order, Pretex.Orders.Order)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def kinds, do: @kinds
+
+  def changeset(r, attrs) do
+    r
+    |> cast(attrs, [:amount_cents, :kind, :note, :gift_card_id, :order_id])
+    |> validate_required([:amount_cents, :kind, :gift_card_id])
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_number(:amount_cents, greater_than: 0)
+  end
+end

--- a/pretex/lib/pretex/orders.ex
+++ b/pretex/lib/pretex/orders.ex
@@ -226,6 +226,16 @@ defmodule Pretex.Orders do
         |> Ecto.Changeset.change(status: "checked_out")
         |> Repo.update!()
 
+        # Preload order_items so discount evaluation can inspect them
+        order_preloaded = Repo.preload(order, order_items: [:item, :item_variation])
+
+        # Apply best automatic discount BEFORE fees (fees computed on discounted price)
+        order =
+          case Pretex.Discounts.apply_best_discount(order_preloaded, cart.event_id) do
+            {:ok, updated} -> updated
+            {:error, _} -> order_preloaded
+          end
+
         order_with_fees =
           case Pretex.Fees.apply_automatic_fees(order, cart.event_id) do
             {:ok, updated_order} -> updated_order
@@ -266,7 +276,11 @@ defmodule Pretex.Orders do
             order_with_fees
           end
 
-        Repo.preload(order_after_voucher, order_items: [:item, :item_variation], fees: [])
+        Repo.preload(order_after_voucher,
+          order_items: [:item, :item_variation],
+          fees: [],
+          discounts: []
+        )
       end)
     end
   end

--- a/pretex/lib/pretex/orders.ex
+++ b/pretex/lib/pretex/orders.ex
@@ -276,10 +276,47 @@ defmodule Pretex.Orders do
             order_with_fees
           end
 
-        Repo.preload(order_after_voucher,
+        # Apply gift card if provided (after voucher, on remaining total)
+        gift_card_code =
+          Map.get(attrs, :gift_card_code) || Map.get(attrs, "gift_card_code")
+
+        order_after_gift_card =
+          if gift_card_code && String.trim(gift_card_code) != "" do
+            event = Repo.get!(Event, cart.event_id)
+
+            case Pretex.GiftCards.validate_for_checkout(gift_card_code, event.organization_id) do
+              {:ok, gift_card} ->
+                case Pretex.GiftCards.redeem(
+                       gift_card,
+                       order_after_voucher,
+                       order_after_voucher.total_cents
+                     ) do
+                  {:ok, %{deduction_cents: deduction}} ->
+                    new_total = max(0, order_after_voucher.total_cents - deduction)
+
+                    {:ok, updated} =
+                      order_after_voucher
+                      |> Ecto.Changeset.change(total_cents: new_total)
+                      |> Repo.update()
+
+                    updated
+
+                  {:error, _} ->
+                    order_after_voucher
+                end
+
+              {:error, _} ->
+                order_after_voucher
+            end
+          else
+            order_after_voucher
+          end
+
+        Repo.preload(order_after_gift_card,
           order_items: [:item, :item_variation],
           fees: [],
-          discounts: []
+          discounts: [],
+          gift_card_redemptions: []
         )
       end)
     end
@@ -533,10 +570,23 @@ defmodule Pretex.Orders do
         )
       end)
 
-      case order |> Ecto.Changeset.change(status: "cancelled") |> Repo.update() do
-        {:ok, updated} -> updated
-        {:error, cs} -> Repo.rollback(cs)
+      cancelled_order =
+        case order |> Ecto.Changeset.change(status: "cancelled") |> Repo.update() do
+          {:ok, updated} -> updated
+          {:error, cs} -> Repo.rollback(cs)
+        end
+
+      # Restore gift card balance if this order was paid with a gift card
+      case Pretex.GiftCards.get_debit_redemption_for_order(order.id) do
+        nil ->
+          :ok
+
+        %{amount_cents: amt} = redemption ->
+          gc = Repo.get!(Pretex.GiftCards.GiftCard, redemption.gift_card_id)
+          Pretex.GiftCards.restore_balance(gc, amt)
       end
+
+      cancelled_order
     end)
   end
 

--- a/pretex/lib/pretex/orders/order.ex
+++ b/pretex/lib/pretex/orders/order.ex
@@ -21,6 +21,7 @@ defmodule Pretex.Orders.Order do
     has_many(:order_items, Pretex.Orders.OrderItem)
     has_many(:fees, Pretex.Fees.OrderFee)
     has_one(:voucher_redemption, Pretex.Vouchers.VoucherRedemption)
+    has_many(:discounts, Pretex.Discounts.OrderDiscount)
 
     timestamps(type: :utc_datetime)
   end

--- a/pretex/lib/pretex/orders/order.ex
+++ b/pretex/lib/pretex/orders/order.ex
@@ -22,6 +22,7 @@ defmodule Pretex.Orders.Order do
     has_many(:fees, Pretex.Fees.OrderFee)
     has_one(:voucher_redemption, Pretex.Vouchers.VoucherRedemption)
     has_many(:discounts, Pretex.Discounts.OrderDiscount)
+    has_many(:gift_card_redemptions, Pretex.GiftCards.GiftCardRedemption)
 
     timestamps(type: :utc_datetime)
   end

--- a/pretex/lib/pretex_web/live/admin/discount_live/index.ex
+++ b/pretex/lib/pretex_web/live/admin/discount_live/index.ex
@@ -1,0 +1,152 @@
+defmodule PretexWeb.Admin.DiscountLive.Index do
+  use PretexWeb, :live_view
+
+  alias Pretex.Events
+  alias Pretex.Organizations
+  alias Pretex.Discounts
+  alias Pretex.Discounts.DiscountRule
+
+  @impl true
+  def mount(%{"org_id" => org_id, "event_id" => event_id}, _session, socket) do
+    org = Organizations.get_organization!(org_id)
+    event = Events.get_event!(event_id)
+    discount_rules = Discounts.list_discount_rules(event)
+
+    socket =
+      socket
+      |> assign(:org, org)
+      |> assign(:event, event)
+      |> assign(:page_title, "Descontos Automáticos — #{event.name}")
+      |> assign(:discount_rule, nil)
+      |> assign(:form, nil)
+      |> stream(:discount_rules, discount_rules)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Descontos Automáticos — #{socket.assigns.event.name}")
+    |> assign(:discount_rule, nil)
+    |> assign(:form, nil)
+  end
+
+  defp apply_action(socket, :new, _params) do
+    rule = %DiscountRule{}
+
+    socket
+    |> assign(:page_title, "Nova Regra de Desconto")
+    |> assign(:discount_rule, rule)
+    |> assign(:form, to_form(Discounts.change_discount_rule(rule)))
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    rule = Discounts.get_discount_rule!(id)
+
+    socket
+    |> assign(:page_title, "Editar Regra de Desconto")
+    |> assign(:discount_rule, rule)
+    |> assign(:form, to_form(Discounts.change_discount_rule(rule)))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def handle_event("validate", %{"discount_rule" => params}, socket) do
+    changeset =
+      socket.assigns.discount_rule
+      |> Discounts.change_discount_rule(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form, to_form(changeset))}
+  end
+
+  def handle_event("save", %{"discount_rule" => params}, socket) do
+    case socket.assigns.live_action do
+      :new -> do_create(socket, params)
+      :edit -> do_update(socket, params)
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    rule = Discounts.get_discount_rule!(id)
+
+    case Discounts.delete_discount_rule(rule) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Regra de desconto removida com sucesso.")
+         |> stream_delete(:discount_rules, rule)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Não foi possível remover a regra de desconto.")}
+    end
+  end
+
+  def handle_event("toggle_active", %{"id" => id}, socket) do
+    rule = Discounts.get_discount_rule!(id)
+    new_active = !rule.active
+
+    case Discounts.update_discount_rule(rule, %{active: new_active}) do
+      {:ok, updated} ->
+        {:noreply, stream_insert(socket, :discount_rules, updated)}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(socket, :error, "Não foi possível alterar o status da regra de desconto.")}
+    end
+  end
+
+  def handle_event("close_modal", _params, socket) do
+    org = socket.assigns.org
+    event = socket.assigns.event
+
+    {:noreply, push_patch(socket, to: ~p"/admin/organizations/#{org}/events/#{event}/discounts")}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp do_create(socket, params) do
+    event = socket.assigns.event
+    org = socket.assigns.org
+
+    case Discounts.create_discount_rule(event, params) do
+      {:ok, rule} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Regra de desconto criada com sucesso.")
+         |> stream_insert(:discount_rules, rule)
+         |> push_patch(to: ~p"/admin/organizations/#{org}/events/#{event}/discounts")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp do_update(socket, params) do
+    rule = socket.assigns.discount_rule
+    event = socket.assigns.event
+    org = socket.assigns.org
+
+    case Discounts.update_discount_rule(rule, params) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Regra de desconto atualizada com sucesso.")
+         |> stream_insert(:discount_rules, updated)
+         |> push_patch(to: ~p"/admin/organizations/#{org}/events/#{event}/discounts")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+end

--- a/pretex/lib/pretex_web/live/admin/discount_live/index.html.heex
+++ b/pretex/lib/pretex_web/live/admin/discount_live/index.html.heex
@@ -1,0 +1,300 @@
+<.dashboard_layout
+  current_path={~p"/admin/organizations/#{@org}/events/#{@event}/discounts"}
+  org={@org}
+  flash={@flash}
+>
+  <div class="mx-auto max-w-5xl px-4 py-8">
+    <%!-- Barra superior --%>
+    <div class="mb-6 flex items-center justify-between gap-4 flex-wrap">
+      <.link
+        navigate={~p"/admin/organizations/#{@org}/events/#{@event}"}
+        class="inline-flex items-center gap-1 text-sm text-base-content/60 hover:text-primary transition-colors"
+      >
+        <.icon name="hero-arrow-left" class="size-4" /> Voltar ao Evento
+      </.link>
+
+      <.link
+        patch={~p"/admin/organizations/#{@org}/events/#{@event}/discounts/new"}
+        class="btn btn-primary btn-sm gap-1"
+      >
+        <.icon name="hero-plus" class="size-4" /> Nova Regra de Desconto
+      </.link>
+    </div>
+
+    <%!-- Título da página --%>
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-base-content">Descontos Automáticos</h1>
+      <p class="text-sm text-base-content/60 mt-1">{@event.name}</p>
+      <p class="text-sm text-base-content/50 mt-2">
+        Regras de desconto são aplicadas automaticamente no checkout. Quando múltiplas regras
+        são elegíveis, apenas a que oferece o maior desconto é aplicada.
+      </p>
+    </div>
+
+    <%!-- Tabela de regras --%>
+    <div class="card bg-base-100 border border-base-200 shadow-sm overflow-hidden">
+      <div id="discount-rules" phx-update="stream">
+        <%!-- Estado vazio --%>
+        <div
+          id="discount-rules-empty-state"
+          class="hidden only:flex flex-col items-center justify-center py-20 text-center px-4"
+        >
+          <.icon name="hero-tag" class="size-12 text-base-content/20 mb-4" />
+          <p class="text-base font-semibold text-base-content/50">
+            Nenhuma regra de desconto cadastrada.
+          </p>
+          <p class="text-sm text-base-content/40 mt-1">
+            Crie regras de desconto automático baseadas em quantidade ou combinação de itens.
+          </p>
+          <.link
+            patch={~p"/admin/organizations/#{@org}/events/#{@event}/discounts/new"}
+            class="btn btn-primary btn-sm mt-6 gap-1"
+          >
+            <.icon name="hero-plus" class="size-4" /> Nova Regra de Desconto
+          </.link>
+        </div>
+
+        <div
+          :for={{dom_id, rule} <- @streams.discount_rules}
+          id={dom_id}
+          class="flex flex-col sm:flex-row sm:items-center gap-3 px-5 py-4 border-b border-base-200 last:border-0 hover:bg-base-50 transition-colors"
+        >
+          <%!-- Nome e descrição --%>
+          <div class="flex-1 min-w-0">
+            <p class="font-semibold text-base-content">{rule.name}</p>
+            <p :if={rule.description} class="text-xs text-base-content/50 mt-0.5">
+              {rule.description}
+            </p>
+          </div>
+
+          <%!-- Condição --%>
+          <div class="shrink-0 text-sm text-base-content/70 min-w-[160px]">
+            <span class="badge badge-ghost badge-sm">
+              {case rule.condition_type do
+                "min_quantity" -> "Qtd mínima: #{rule.min_quantity}"
+                "item_combo" -> "Combinação de itens"
+                other -> other
+              end}
+            </span>
+          </div>
+
+          <%!-- Efeito --%>
+          <div class="shrink-0 text-right min-w-[160px]">
+            <p class="font-mono font-semibold text-base-content text-sm">
+              {case rule.value_type do
+                "fixed" ->
+                  reais = div(rule.value, 100)
+                  cents = rem(rule.value, 100)
+
+                  "R$ #{reais},#{String.pad_leading(Integer.to_string(cents), 2, "0")} de desconto"
+
+                "percentage" ->
+                  int_part = div(rule.value, 100)
+                  dec_part = rem(rule.value, 100)
+
+                  "#{int_part},#{String.pad_leading(Integer.to_string(dec_part), 2, "0")}% de desconto"
+
+                _ ->
+                  "—"
+              end}
+            </p>
+          </div>
+
+          <%!-- Status ativo --%>
+          <div class="shrink-0">
+            <span class={[
+              "badge badge-sm",
+              rule.active && "badge-success",
+              !rule.active && "badge-error"
+            ]}>
+              {if rule.active, do: "Ativo", else: "Inativo"}
+            </span>
+          </div>
+
+          <%!-- Ações --%>
+          <div class="flex items-center gap-2 shrink-0">
+            <button
+              id={"toggle-#{rule.id}"}
+              phx-click="toggle_active"
+              phx-value-id={rule.id}
+              class="btn btn-ghost btn-xs"
+              title={if rule.active, do: "Desativar", else: "Ativar"}
+            >
+              {if rule.active, do: "Desativar", else: "Ativar"}
+            </button>
+
+            <.link
+              patch={~p"/admin/organizations/#{@org}/events/#{@event}/discounts/#{rule.id}/edit"}
+              class="btn btn-ghost btn-xs"
+            >
+              Editar
+            </.link>
+
+            <button
+              id={"delete-#{rule.id}"}
+              phx-click="delete"
+              phx-value-id={rule.id}
+              data-confirm="Excluir esta regra de desconto? Esta ação não pode ser desfeita."
+              class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-error-content"
+            >
+              Excluir
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Modal: Nova / Editar Regra de Desconto --%>
+  <div :if={@live_action in [:new, :edit]}>
+    <div
+      id="discount-modal-backdrop"
+      class="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+      phx-click="close_modal"
+    >
+    </div>
+
+    <div
+      id="discount-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        class="w-full max-w-lg bg-base-100 rounded-2xl shadow-2xl border border-base-200 overflow-hidden max-h-[90vh] flex flex-col"
+        phx-click-away="close_modal"
+      >
+        <%!-- Cabeçalho do modal --%>
+        <div class="flex items-center justify-between px-6 py-4 border-b border-base-200 shrink-0">
+          <h2 class="text-lg font-bold text-base-content">
+            {if @live_action == :new,
+              do: "Nova Regra de Desconto",
+              else: "Editar Regra de Desconto"}
+          </h2>
+          <button
+            type="button"
+            phx-click="close_modal"
+            class="btn btn-ghost btn-sm btn-circle"
+            aria-label="Fechar"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
+
+        <%!-- Corpo do modal --%>
+        <div class="px-6 py-5 overflow-y-auto">
+          <.form
+            for={@form}
+            id="discount-rule-form"
+            phx-change="validate"
+            phx-submit="save"
+            class="space-y-4"
+          >
+            <%!-- Nome --%>
+            <div>
+              <.input
+                field={@form[:name]}
+                type="text"
+                label="Nome"
+                placeholder="Ex: Desconto em Grupo"
+                required
+              />
+            </div>
+
+            <%!-- Tipo de Condição --%>
+            <.input
+              field={@form[:condition_type]}
+              type="select"
+              label="Tipo de Condição"
+              options={[
+                {"Quantidade mínima", "min_quantity"},
+                {"Combinação de itens", "item_combo"}
+              ]}
+            />
+
+            <%!-- Quantidade mínima (mostrada quando condition_type == min_quantity) --%>
+            <div :if={@form[:condition_type].value == "min_quantity"}>
+              <.input
+                field={@form[:min_quantity]}
+                type="number"
+                label="Quantidade Mínima"
+                min="1"
+                required
+              />
+              <p class="text-xs text-base-content/50 mt-1">
+                O desconto é aplicado quando a quantidade total de itens no carrinho atingir este valor.
+              </p>
+            </div>
+
+            <div :if={@form[:condition_type].value == "item_combo"}>
+              <div class="rounded-lg bg-info/10 border border-info/20 p-3 text-sm text-base-content/70">
+                <.icon name="hero-information-circle" class="size-4 inline mr-1 text-info" />
+                Gerencie os itens necessários para esta combinação via API ou diretamente no banco de dados.
+              </div>
+            </div>
+
+            <%!-- Tipo de Valor --%>
+            <.input
+              field={@form[:value_type]}
+              type="select"
+              label="Tipo de Desconto"
+              options={[
+                {"Percentual (pontos base)", "percentage"},
+                {"Fixo (centavos)", "fixed"}
+              ]}
+            />
+
+            <%!-- Valor --%>
+            <div>
+              <.input
+                field={@form[:value]}
+                type="number"
+                label="Valor"
+                min="0"
+                required
+              />
+              <p class="text-xs text-base-content/50 mt-1">
+                {case @form[:value_type].value do
+                  "fixed" -> "Em centavos: 1000 = R$ 10,00 · 500 = R$ 5,00"
+                  "percentage" -> "Em pontos base: 500 = 5,00% · 1000 = 10,00% · 10000 = 100,00%"
+                  _ -> ""
+                end}
+              </p>
+            </div>
+
+            <%!-- Descrição --%>
+            <div>
+              <.input
+                field={@form[:description]}
+                type="textarea"
+                label="Descrição (opcional)"
+                placeholder="Descrição interna da regra de desconto"
+                rows="2"
+              />
+            </div>
+
+            <%!-- Ativo --%>
+            <.input
+              field={@form[:active]}
+              type="checkbox"
+              label="Ativo"
+            />
+            <p class="text-xs text-base-content/50 -mt-3 ml-1">
+              Regras inativas não são avaliadas no checkout.
+            </p>
+
+            <%!-- Botões --%>
+            <div class="flex justify-end gap-3 pt-2">
+              <button type="button" phx-click="close_modal" class="btn btn-ghost btn-sm">
+                Cancelar
+              </button>
+              <.button type="submit" variant="primary" phx-disable-with="Salvando...">
+                {if @live_action == :new, do: "Criar Regra", else: "Salvar Alterações"}
+              </.button>
+            </div>
+          </.form>
+        </div>
+      </div>
+    </div>
+  </div>
+</.dashboard_layout>

--- a/pretex/lib/pretex_web/live/admin/event_live/show.html.heex
+++ b/pretex/lib/pretex_web/live/admin/event_live/show.html.heex
@@ -358,6 +358,32 @@
       </div>
     </div>
 
+    <%!-- Card de descontos automáticos --%>
+    <div class="card bg-base-100 border border-base-200 shadow-sm mb-4">
+      <div class="card-body p-6">
+        <div class="flex items-center justify-between gap-4 mb-4">
+          <h2 class="text-base font-semibold text-base-content flex items-center gap-2">
+            <.icon name="hero-tag" class="size-4 text-base-content/40" /> Descontos Automáticos
+          </h2>
+          <.link
+            navigate={~p"/admin/organizations/#{@org}/events/#{@event}/discounts"}
+            class="btn btn-ghost btn-xs gap-1"
+          >
+            <.icon name="hero-arrow-right" class="size-3" /> Gerenciar Descontos
+          </.link>
+        </div>
+        <div class="flex items-start gap-3 rounded-lg bg-base-200 border border-base-300 p-4 text-sm">
+          <.icon
+            name="hero-information-circle"
+            class="size-5 shrink-0 text-base-content/40 mt-0.5"
+          />
+          <p class="text-base-content/70">
+            Crie regras de desconto automático baseadas em quantidade mínima ou combinação de itens. O melhor desconto elegível é aplicado automaticamente no checkout.
+          </p>
+        </div>
+      </div>
+    </div>
+
     <%!-- Card de pedidos --%>
     <div class="card bg-base-100 border border-base-200 shadow-sm mb-4">
       <div class="card-body p-6">

--- a/pretex/lib/pretex_web/live/admin/gift_card_live/index.ex
+++ b/pretex/lib/pretex_web/live/admin/gift_card_live/index.ex
@@ -1,0 +1,224 @@
+defmodule PretexWeb.Admin.GiftCardLive.Index do
+  use PretexWeb, :live_view
+
+  alias Pretex.Organizations
+  alias Pretex.GiftCards
+  alias Pretex.GiftCards.GiftCard
+
+  @impl true
+  def mount(%{"org_id" => org_id}, _session, socket) do
+    org = Organizations.get_organization!(org_id)
+    gift_cards = GiftCards.list_gift_cards(org)
+
+    socket =
+      socket
+      |> assign(:org, org)
+      |> assign(:page_title, "Vale-Presentes — #{org.name}")
+      |> assign(:gift_card, nil)
+      |> assign(:form, nil)
+      |> assign(:top_up_form, nil)
+      |> stream(:gift_cards, gift_cards)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Vale-Presentes — #{socket.assigns.org.name}")
+    |> assign(:gift_card, nil)
+    |> assign(:form, nil)
+    |> assign(:top_up_form, nil)
+  end
+
+  defp apply_action(socket, :new, _params) do
+    gift_card = %GiftCard{}
+    generated_code = GiftCards.generate_code()
+
+    socket
+    |> assign(:page_title, "Novo Vale-Presente")
+    |> assign(:gift_card, gift_card)
+    |> assign(
+      :form,
+      to_form(GiftCards.change_gift_card(gift_card, %{code: generated_code}))
+    )
+    |> assign(:top_up_form, nil)
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    gift_card = GiftCards.get_gift_card!(id)
+
+    socket
+    |> assign(:page_title, "Editar Vale-Presente")
+    |> assign(:gift_card, gift_card)
+    |> assign(:form, to_form(GiftCards.change_gift_card(gift_card)))
+    |> assign(:top_up_form, nil)
+  end
+
+  defp apply_action(socket, :top_up, %{"id" => id}) do
+    gift_card = GiftCards.get_gift_card!(id)
+
+    socket
+    |> assign(:page_title, "Recarregar Vale-Presente")
+    |> assign(:gift_card, gift_card)
+    |> assign(:form, nil)
+    |> assign(:top_up_form, to_form(%{"amount_cents" => ""}, as: :top_up))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def handle_event("validate", %{"gift_card" => params}, socket) do
+    changeset =
+      socket.assigns.gift_card
+      |> GiftCards.change_gift_card(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form, to_form(changeset))}
+  end
+
+  def handle_event("save", %{"gift_card" => params}, socket) do
+    case socket.assigns.live_action do
+      :new -> do_create(socket, params)
+      :edit -> do_update(socket, params)
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    gift_card = GiftCards.get_gift_card!(id)
+
+    case GiftCards.delete_gift_card(gift_card) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Vale-presente removido com sucesso.")
+         |> stream_delete(:gift_cards, gift_card)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Não foi possível remover o vale-presente.")}
+    end
+  end
+
+  def handle_event("toggle_active", %{"id" => id}, socket) do
+    gift_card = GiftCards.get_gift_card!(id)
+    new_active = !gift_card.active
+
+    case GiftCards.update_gift_card(gift_card, %{active: new_active}) do
+      {:ok, updated} ->
+        {:noreply, stream_insert(socket, :gift_cards, updated)}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(socket, :error, "Não foi possível alterar o status do vale-presente.")}
+    end
+  end
+
+  def handle_event("save_top_up", %{"top_up" => %{"amount_cents" => amt_str}}, socket) do
+    org = socket.assigns.org
+    gift_card = socket.assigns.gift_card
+
+    case parse_integer(amt_str) do
+      amount when is_integer(amount) and amount > 0 ->
+        case GiftCards.top_up(gift_card, amount) do
+          {:ok, updated_gc} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Vale-presente recarregado com sucesso.")
+             |> stream_insert(:gift_cards, updated_gc)
+             |> push_patch(to: ~p"/admin/organizations/#{org}/gift-cards")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Não foi possível recarregar o vale-presente.")}
+        end
+
+      _ ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Por favor informe um valor válido maior que zero.")
+         |> assign(:top_up_form, to_form(%{"amount_cents" => amt_str}, as: :top_up))}
+    end
+  end
+
+  def handle_event("generate_code", _, socket) do
+    new_code = GiftCards.generate_code()
+    gift_card = socket.assigns.gift_card
+
+    changeset = GiftCards.change_gift_card(gift_card, %{code: new_code})
+
+    {:noreply, assign(socket, :form, to_form(changeset))}
+  end
+
+  def handle_event("close_modal", _params, socket) do
+    org = socket.assigns.org
+    {:noreply, push_patch(socket, to: ~p"/admin/organizations/#{org}/gift-cards")}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp do_create(socket, params) do
+    org = socket.assigns.org
+
+    case GiftCards.create_gift_card(org, params) do
+      {:ok, gift_card} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Vale-presente criado com sucesso.")
+         |> stream_insert(:gift_cards, gift_card)
+         |> push_patch(to: ~p"/admin/organizations/#{org}/gift-cards")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp do_update(socket, params) do
+    org = socket.assigns.org
+    gift_card = socket.assigns.gift_card
+
+    case GiftCards.update_gift_card(gift_card, params) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Vale-presente atualizado com sucesso.")
+         |> stream_insert(:gift_cards, updated)
+         |> push_patch(to: ~p"/admin/organizations/#{org}/gift-cards")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp parse_integer(v) when is_binary(v) do
+    trimmed = String.trim(v)
+
+    case Integer.parse(trimmed) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_integer(v) when is_integer(v), do: v
+  defp parse_integer(_), do: nil
+
+  defp format_balance(cents) when is_integer(cents) do
+    reais = div(cents, 100)
+    centavos = rem(cents, 100)
+    "R$ #{reais},#{String.pad_leading(Integer.to_string(centavos), 2, "0")}"
+  end
+
+  defp format_balance(_), do: "R$ 0,00"
+
+  defp format_expiry(nil), do: "Nunca expira"
+
+  defp format_expiry(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%d/%m/%Y %H:%M")
+  end
+end

--- a/pretex/lib/pretex_web/live/admin/gift_card_live/index.html.heex
+++ b/pretex/lib/pretex_web/live/admin/gift_card_live/index.html.heex
@@ -1,0 +1,351 @@
+<.dashboard_layout
+  current_path={~p"/admin/organizations/#{@org}/gift-cards"}
+  org={@org}
+  flash={@flash}
+>
+  <div class="mx-auto max-w-5xl px-4 py-8">
+    <%!-- Barra superior --%>
+    <div class="mb-6 flex items-center justify-between gap-4 flex-wrap">
+      <.link
+        navigate={~p"/admin/organizations/#{@org}"}
+        class="inline-flex items-center gap-1 text-sm text-base-content/60 hover:text-primary transition-colors"
+      >
+        <.icon name="hero-arrow-left" class="size-4" /> Voltar à Organização
+      </.link>
+
+      <.link
+        patch={~p"/admin/organizations/#{@org}/gift-cards/new"}
+        class="btn btn-primary btn-sm gap-1"
+      >
+        <.icon name="hero-plus" class="size-4" /> Novo Vale-Presente
+      </.link>
+    </div>
+
+    <%!-- Título da página --%>
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-base-content">Vale-Presentes</h1>
+      <p class="text-sm text-base-content/60 mt-1">{@org.name}</p>
+    </div>
+
+    <%!-- Tabela de vale-presentes --%>
+    <div class="card bg-base-100 border border-base-200 shadow-sm overflow-hidden">
+      <div id="gift_cards" phx-update="stream">
+        <%!-- Estado vazio --%>
+        <div
+          id="gift_cards-empty-state"
+          class="hidden only:flex flex-col items-center justify-center py-20 text-center px-4"
+        >
+          <.icon name="hero-gift" class="size-12 text-base-content/20 mb-4" />
+          <p class="text-base font-semibold text-base-content/50">
+            Nenhum vale-presente cadastrado.
+          </p>
+          <p class="text-sm text-base-content/40 mt-1">
+            Crie vale-presentes para oferecer créditos reutilizáveis em todos os eventos da organização.
+          </p>
+          <.link
+            patch={~p"/admin/organizations/#{@org}/gift-cards/new"}
+            class="btn btn-primary btn-sm mt-6 gap-1"
+          >
+            <.icon name="hero-plus" class="size-4" /> Novo Vale-Presente
+          </.link>
+        </div>
+
+        <div
+          :for={{dom_id, gc} <- @streams.gift_cards}
+          id={dom_id}
+          class="flex flex-col sm:flex-row sm:items-center gap-3 px-5 py-4 border-b border-base-200 last:border-0 hover:bg-base-50 transition-colors"
+        >
+          <%!-- Código e nota --%>
+          <div class="flex-1 min-w-0">
+            <p class="font-mono font-bold text-base-content tracking-wider">{gc.code}</p>
+            <p :if={gc.note} class="text-xs text-base-content/50 mt-0.5">{gc.note}</p>
+          </div>
+
+          <%!-- Saldo atual --%>
+          <div class="shrink-0 text-right min-w-[110px]">
+            <p class="font-semibold text-base-content">
+              {format_balance(gc.balance_cents)}
+            </p>
+            <p class="text-xs text-base-content/40">
+              de {format_balance(gc.initial_balance_cents)}
+            </p>
+          </div>
+
+          <%!-- Expiração --%>
+          <div class="shrink-0 text-right min-w-[120px]">
+            <p class="text-xs text-base-content/60">
+              {format_expiry(gc.expires_at)}
+            </p>
+          </div>
+
+          <%!-- Status ativo --%>
+          <div class="shrink-0">
+            <span class={[
+              "badge badge-sm",
+              gc.active && "badge-success",
+              !gc.active && "badge-error"
+            ]}>
+              {if gc.active, do: "Ativo", else: "Inativo"}
+            </span>
+          </div>
+
+          <%!-- Ações --%>
+          <div class="flex items-center gap-2 shrink-0">
+            <button
+              phx-click="toggle_active"
+              phx-value-id={gc.id}
+              class="btn btn-ghost btn-xs"
+              title={if gc.active, do: "Desativar", else: "Ativar"}
+            >
+              {if gc.active, do: "Desativar", else: "Ativar"}
+            </button>
+
+            <.link
+              patch={~p"/admin/organizations/#{@org}/gift-cards/#{gc.id}/top-up"}
+              class="btn btn-ghost btn-xs"
+            >
+              Recarregar
+            </.link>
+
+            <.link
+              patch={~p"/admin/organizations/#{@org}/gift-cards/#{gc.id}/edit"}
+              class="btn btn-ghost btn-xs"
+            >
+              Editar
+            </.link>
+
+            <button
+              phx-click="delete"
+              phx-value-id={gc.id}
+              data-confirm="Excluir este vale-presente? Esta ação não pode ser desfeita."
+              class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-error-content"
+            >
+              Excluir
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Modal: Novo / Editar Vale-Presente --%>
+  <div :if={@live_action in [:new, :edit]}>
+    <div
+      id="gift-card-modal-backdrop"
+      class="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+      phx-click="close_modal"
+    >
+    </div>
+
+    <div
+      id="gift-card-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        class="w-full max-w-lg bg-base-100 rounded-2xl shadow-2xl border border-base-200 overflow-hidden max-h-[90vh] flex flex-col"
+        phx-click-away="close_modal"
+      >
+        <%!-- Cabeçalho do modal --%>
+        <div class="flex items-center justify-between px-6 py-4 border-b border-base-200 shrink-0">
+          <h2 class="text-lg font-bold text-base-content">
+            {if @live_action == :new, do: "Novo Vale-Presente", else: "Editar Vale-Presente"}
+          </h2>
+          <button
+            type="button"
+            phx-click="close_modal"
+            class="btn btn-ghost btn-sm btn-circle"
+            aria-label="Fechar"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
+
+        <%!-- Corpo do modal --%>
+        <div class="px-6 py-5 overflow-y-auto">
+          <.form
+            for={@form}
+            id="gift-card-form"
+            phx-change="validate"
+            phx-submit="save"
+            class="space-y-4"
+          >
+            <%!-- Código --%>
+            <div>
+              <label class="label">
+                <span class="label-text font-medium">Código</span>
+              </label>
+              <div class="flex gap-2">
+                <.input
+                  field={@form[:code]}
+                  type="text"
+                  placeholder="Ex: GC-AB3K9F12"
+                  class="flex-1"
+                />
+                <button
+                  type="button"
+                  phx-click="generate_code"
+                  class="btn btn-outline btn-sm self-end mb-[2px]"
+                >
+                  Gerar
+                </button>
+              </div>
+              <p class="text-xs text-base-content/50 mt-1">
+                O código será convertido para maiúsculas automaticamente. Deve ser único na plataforma.
+              </p>
+            </div>
+
+            <%!-- Saldo (em centavos) --%>
+            <div>
+              <.input
+                field={@form[:balance_cents]}
+                type="number"
+                label="Saldo (em centavos)"
+                min="0"
+                placeholder="Ex: 5000 = R$ 50,00"
+              />
+              <p class="text-xs text-base-content/50 mt-1">
+                1000 = R$ 10,00 · 5000 = R$ 50,00 · 10000 = R$ 100,00
+              </p>
+            </div>
+
+            <%!-- Saldo inicial (em centavos) --%>
+            <div>
+              <.input
+                field={@form[:initial_balance_cents]}
+                type="number"
+                label="Saldo Inicial (em centavos)"
+                min="0"
+                placeholder="Deixe em branco para usar o saldo acima"
+              />
+              <p class="text-xs text-base-content/50 mt-1">
+                Valor original do vale-presente (para exibição). Se não informado, será igual ao saldo.
+              </p>
+            </div>
+
+            <%!-- Expiração --%>
+            <div>
+              <.input
+                field={@form[:expires_at]}
+                type="datetime-local"
+                label="Expiração (opcional)"
+              />
+              <p class="text-xs text-base-content/50 mt-1">
+                Deixe em branco para vale-presente sem prazo de validade.
+              </p>
+            </div>
+
+            <%!-- Nota --%>
+            <.input
+              field={@form[:note]}
+              type="text"
+              label="Nota (opcional)"
+              placeholder="Ex: Presente de aniversário, Compensação de reembolso..."
+            />
+
+            <%!-- Ativo --%>
+            <.input
+              field={@form[:active]}
+              type="checkbox"
+              label="Ativo"
+            />
+            <p class="text-xs text-base-content/50 -mt-3 ml-1">
+              Vale-presentes inativos não podem ser utilizados no checkout.
+            </p>
+
+            <%!-- Botões --%>
+            <div class="flex justify-end gap-3 pt-2">
+              <button type="button" phx-click="close_modal" class="btn btn-ghost btn-sm">
+                Cancelar
+              </button>
+              <.button type="submit" variant="primary" phx-disable-with="Salvando...">
+                {if @live_action == :new, do: "Criar Vale-Presente", else: "Salvar Alterações"}
+              </.button>
+            </div>
+          </.form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Modal: Recarregar Vale-Presente --%>
+  <div :if={@live_action == :top_up}>
+    <div
+      id="top-up-modal-backdrop"
+      class="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+      phx-click="close_modal"
+    >
+    </div>
+
+    <div
+      id="top-up-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        class="w-full max-w-md bg-base-100 rounded-2xl shadow-2xl border border-base-200 overflow-hidden"
+        phx-click-away="close_modal"
+      >
+        <%!-- Cabeçalho do modal --%>
+        <div class="flex items-center justify-between px-6 py-4 border-b border-base-200">
+          <div>
+            <h2 class="text-lg font-bold text-base-content">Recarregar Vale-Presente</h2>
+            <p class="text-sm text-base-content/60 font-mono mt-0.5">
+              {@gift_card && @gift_card.code}
+            </p>
+          </div>
+          <button
+            type="button"
+            phx-click="close_modal"
+            class="btn btn-ghost btn-sm btn-circle"
+            aria-label="Fechar"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
+
+        <%!-- Corpo do modal --%>
+        <div class="px-6 py-5">
+          <div :if={@gift_card} class="mb-4 p-3 rounded-lg bg-base-200 text-sm">
+            <span class="text-base-content/60">Saldo atual:</span>
+            <span class="font-bold text-base-content ml-2">
+              {format_balance(@gift_card.balance_cents)}
+            </span>
+          </div>
+
+          <.form
+            for={@top_up_form}
+            id="top-up-form"
+            phx-submit="save_top_up"
+            class="space-y-4"
+          >
+            <div>
+              <.input
+                field={@top_up_form[:amount_cents]}
+                type="number"
+                label="Valor a adicionar (em centavos)"
+                min="1"
+                placeholder="Ex: 5000 = R$ 50,00"
+                required
+              />
+              <p class="text-xs text-base-content/50 mt-1">
+                1000 = R$ 10,00 · 5000 = R$ 50,00 · 10000 = R$ 100,00
+              </p>
+            </div>
+
+            <div class="flex justify-end gap-3 pt-2">
+              <button type="button" phx-click="close_modal" class="btn btn-ghost btn-sm">
+                Cancelar
+              </button>
+              <.button type="submit" variant="primary" phx-disable-with="Recarregando...">
+                Recarregar
+              </.button>
+            </div>
+          </.form>
+        </div>
+      </div>
+    </div>
+  </div>
+</.dashboard_layout>

--- a/pretex/lib/pretex_web/live/admin/organization_live/show.html.heex
+++ b/pretex/lib/pretex_web/live/admin/organization_live/show.html.heex
@@ -51,6 +51,21 @@
       </div>
     </a>
 
+    <a
+      href={~p"/admin/organizations/#{@organization}/gift-cards"}
+      class="bg-base-100 rounded-xl border border-base-300 p-5 hover:shadow-lg hover:-translate-y-1 transition group"
+    >
+      <div class="flex items-center gap-4">
+        <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition">
+          <.icon name="hero-gift" class="w-6 h-6 text-primary" />
+        </div>
+        <div>
+          <div class="font-bold text-base-content">Vale-Presentes</div>
+          <div class="text-sm text-base-content/50">Gerenciar vale-presentes da organização</div>
+        </div>
+      </div>
+    </a>
+
     <div class="bg-base-100 rounded-xl border border-base-300 p-5 opacity-50">
       <div class="flex items-center gap-4">
         <div class="w-12 h-12 rounded-xl bg-base-200 flex items-center justify-center">

--- a/pretex/lib/pretex_web/live/events_live/checkout.ex
+++ b/pretex/lib/pretex_web/live/events_live/checkout.ex
@@ -132,7 +132,10 @@ defmodule PretexWeb.EventsLive.Checkout do
 
               <%!-- Subtotal line (shown when there are fees or discount) --%>
               <div
-                :if={@fee_preview != [] or @discount_preview > 0}
+                :if={
+                  @fee_preview != [] or @discount_preview > 0 or @voucher_discount > 0 or
+                    @gift_card_deduction > 0
+                }
                 class="flex justify-between items-center pt-2 text-sm text-base-content/70"
               >
                 <span>Subtotal</span>
@@ -214,12 +217,51 @@ defmodule PretexWeb.EventsLive.Checkout do
                 </div>
               </div>
 
+              <%!-- Gift card code input (shown when no gift card applied) --%>
+              <div :if={is_nil(@gift_card)} class="pt-2">
+                <form phx-submit="apply_gift_card" class="flex gap-2">
+                  <input
+                    type="text"
+                    name="code"
+                    placeholder="Código do vale-presente"
+                    class="input input-bordered input-sm flex-1 font-mono"
+                    autocomplete="off"
+                  />
+                  <button type="submit" class="btn btn-sm btn-outline">Aplicar</button>
+                </form>
+                <p :if={@gift_card_error} class="text-xs text-error mt-1">{@gift_card_error}</p>
+              </div>
+
+              <%!-- Applied gift card badge --%>
+              <div
+                :if={@gift_card}
+                class="flex justify-between items-center text-sm"
+              >
+                <span class="flex items-center gap-2">
+                  <span class="badge badge-success badge-sm gap-1">
+                    <.icon name="hero-gift" class="size-3" />
+                    {@gift_card.code}
+                  </span>
+                  <button
+                    phx-click="remove_gift_card"
+                    class="text-xs text-base-content/40 hover:text-error"
+                  >
+                    Remover
+                  </button>
+                </span>
+                <span class="text-success font-medium">- {format_price(@gift_card_deduction)}</span>
+              </div>
+
               <%!-- Total line --%>
               <div class="flex justify-between items-center pt-3 mt-2 border-t-2 border-base-200">
                 <span class="font-bold text-base-content">Total</span>
                 <span class="text-xl font-bold text-primary">
                   {format_price(
-                    max(0, @cart_total + @fee_total - @discount_preview - @voucher_discount)
+                    max(
+                      0,
+                      @cart_total + @fee_total - @discount_preview - @voucher_discount -
+                        @gift_card_deduction
+                    )
                   )}
                 </span>
               </div>
@@ -493,6 +535,10 @@ defmodule PretexWeb.EventsLive.Checkout do
       |> assign(:voucher_discount, 0)
       |> assign(:discount_preview, 0)
       |> assign(:applied_discount_rule_name, nil)
+      |> assign(:gift_card_code, "")
+      |> assign(:gift_card, nil)
+      |> assign(:gift_card_error, nil)
+      |> assign(:gift_card_deduction, 0)
 
     {:ok, socket}
   end
@@ -726,7 +772,8 @@ defmodule PretexWeb.EventsLive.Checkout do
         email: email,
         payment_method: payment_method,
         payment_provider_id: provider_id && String.to_integer(provider_id),
-        voucher_code: socket.assigns.voucher_code
+        voucher_code: socket.assigns.voucher_code,
+        gift_card_code: socket.assigns.gift_card_code
       }
 
       case Orders.create_order_from_cart(cart, attrs) do
@@ -815,6 +862,76 @@ defmodule PretexWeb.EventsLive.Checkout do
      |> assign(:voucher, nil)
      |> assign(:voucher_error, nil)
      |> assign(:voucher_discount, 0)}
+  end
+
+  def handle_event("apply_gift_card", %{"code" => code}, socket) do
+    code = String.trim(code)
+
+    if code == "" do
+      {:noreply, assign(socket, :gift_card_error, "Por favor insira um código de vale-presente.")}
+    else
+      org_id = socket.assigns.event.organization_id
+
+      case Pretex.GiftCards.validate_for_checkout(code, org_id) do
+        {:ok, gc} ->
+          remaining_total =
+            socket.assigns.cart_total + socket.assigns.fee_total -
+              socket.assigns.discount_preview - socket.assigns.voucher_discount
+
+          deduction = min(gc.balance_cents, max(0, remaining_total))
+
+          {:noreply,
+           socket
+           |> assign(:gift_card_code, String.upcase(code))
+           |> assign(:gift_card, gc)
+           |> assign(:gift_card_error, nil)
+           |> assign(:gift_card_deduction, deduction)}
+
+        {:error, :not_found} ->
+          {:noreply,
+           socket
+           |> assign(:gift_card_error, "Vale-presente não encontrado.")
+           |> assign(:gift_card, nil)
+           |> assign(:gift_card_deduction, 0)}
+
+        {:error, :wrong_organization} ->
+          {:noreply,
+           socket
+           |> assign(:gift_card_error, "Este vale-presente não é válido para este evento.")
+           |> assign(:gift_card, nil)
+           |> assign(:gift_card_deduction, 0)}
+
+        {:error, :expired} ->
+          {:noreply,
+           socket
+           |> assign(:gift_card_error, "Vale-presente expirado.")
+           |> assign(:gift_card, nil)
+           |> assign(:gift_card_deduction, 0)}
+
+        {:error, :empty} ->
+          {:noreply,
+           socket
+           |> assign(:gift_card_error, "Vale-presente sem saldo.")
+           |> assign(:gift_card, nil)
+           |> assign(:gift_card_deduction, 0)}
+
+        {:error, :inactive} ->
+          {:noreply,
+           socket
+           |> assign(:gift_card_error, "Vale-presente inativo.")
+           |> assign(:gift_card, nil)
+           |> assign(:gift_card_deduction, 0)}
+      end
+    end
+  end
+
+  def handle_event("remove_gift_card", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:gift_card_code, "")
+     |> assign(:gift_card, nil)
+     |> assign(:gift_card_error, nil)
+     |> assign(:gift_card_deduction, 0)}
   end
 
   def handle_event("retry_payment", _params, socket) do

--- a/pretex/lib/pretex_web/live/events_live/checkout.ex
+++ b/pretex/lib/pretex_web/live/events_live/checkout.ex
@@ -130,13 +130,25 @@ defmodule PretexWeb.EventsLive.Checkout do
                 </span>
               </div>
 
-              <%!-- Subtotal line (shown when there are fees) --%>
+              <%!-- Subtotal line (shown when there are fees or discount) --%>
               <div
-                :if={@fee_preview != []}
+                :if={@fee_preview != [] or @discount_preview > 0}
                 class="flex justify-between items-center pt-2 text-sm text-base-content/70"
               >
                 <span>Subtotal</span>
                 <span>{format_price(@cart_total)}</span>
+              </div>
+
+              <%!-- Automatic discount row --%>
+              <div
+                :if={@discount_preview > 0}
+                class="flex justify-between items-center text-sm text-success"
+              >
+                <span class="flex items-center gap-1">
+                  <.icon name="hero-tag" class="size-3" />
+                  {@applied_discount_rule_name || "Desconto Automático"}
+                </span>
+                <span>- {format_price(@discount_preview)}</span>
               </div>
 
               <%!-- Fee preview rows --%>
@@ -206,7 +218,9 @@ defmodule PretexWeb.EventsLive.Checkout do
               <div class="flex justify-between items-center pt-3 mt-2 border-t-2 border-base-200">
                 <span class="font-bold text-base-content">Total</span>
                 <span class="text-xl font-bold text-primary">
-                  {format_price(max(0, @cart_total + @fee_total - @voucher_discount))}
+                  {format_price(
+                    max(0, @cart_total + @fee_total - @discount_preview - @voucher_discount)
+                  )}
                 </span>
               </div>
             </div>
@@ -477,6 +491,8 @@ defmodule PretexWeb.EventsLive.Checkout do
       |> assign(:voucher, nil)
       |> assign(:voucher_error, nil)
       |> assign(:voucher_discount, 0)
+      |> assign(:discount_preview, 0)
+      |> assign(:applied_discount_rule_name, nil)
 
     {:ok, socket}
   end
@@ -505,12 +521,36 @@ defmodule PretexWeb.EventsLive.Checkout do
               fee_preview = Pretex.Fees.compute_fees_for_cart(event, subtotal)
               fee_total = Pretex.Fees.total_fees_cents(fee_preview)
 
+              cart_items =
+                Enum.map(cart.cart_items, fn ci ->
+                  %{
+                    item_id: ci.item_id,
+                    item_variation_id: ci.item_variation_id,
+                    quantity: ci.quantity,
+                    unit_price_cents:
+                      if(ci.item_variation && ci.item_variation.price_cents,
+                        do: ci.item_variation.price_cents,
+                        else: ci.item.price_cents
+                      )
+                  }
+                end)
+
+              discount_preview = Pretex.Discounts.compute_discount_for_cart(event.id, cart_items)
+
+              {discount_rule_name, _} =
+                case Pretex.Discounts.best_discount(event.id, cart_items) do
+                  {:ok, %{rule: r}} -> {r.name, nil}
+                  _ -> {nil, nil}
+                end
+
               socket
               |> assign(:cart, cart)
               |> assign(:cart_total, subtotal)
               |> assign(:payment_options, payment_options)
               |> assign(:fee_preview, fee_preview)
               |> assign(:fee_total, fee_total)
+              |> assign(:discount_preview, discount_preview)
+              |> assign(:applied_discount_rule_name, discount_rule_name)
             else
               socket
               |> put_flash(:error, "Seu carrinho expirou. Por favor comece novamente.")

--- a/pretex/lib/pretex_web/router.ex
+++ b/pretex/lib/pretex_web/router.ex
@@ -183,6 +183,11 @@ defmodule PretexWeb.Router do
         DiscountLive.Index,
         :edit
       )
+
+      live("/organizations/:org_id/gift-cards", GiftCardLive.Index, :index)
+      live("/organizations/:org_id/gift-cards/new", GiftCardLive.Index, :new)
+      live("/organizations/:org_id/gift-cards/:id/edit", GiftCardLive.Index, :edit)
+      live("/organizations/:org_id/gift-cards/:id/top-up", GiftCardLive.Index, :top_up)
     end
   end
 

--- a/pretex/lib/pretex_web/router.ex
+++ b/pretex/lib/pretex_web/router.ex
@@ -174,6 +174,15 @@ defmodule PretexWeb.Router do
       live("/organizations/:org_id/events/:event_id/vouchers/new", VoucherLive.Index, :new)
       live("/organizations/:org_id/events/:event_id/vouchers/bulk", VoucherLive.Index, :bulk)
       live("/organizations/:org_id/events/:event_id/vouchers/:id/edit", VoucherLive.Index, :edit)
+
+      live("/organizations/:org_id/events/:event_id/discounts", DiscountLive.Index, :index)
+      live("/organizations/:org_id/events/:event_id/discounts/new", DiscountLive.Index, :new)
+
+      live(
+        "/organizations/:org_id/events/:event_id/discounts/:id/edit",
+        DiscountLive.Index,
+        :edit
+      )
     end
   end
 

--- a/pretex/priv/repo/migrations/20260319270001_create_discount_rules.exs
+++ b/pretex/priv/repo/migrations/20260319270001_create_discount_rules.exs
@@ -1,0 +1,22 @@
+defmodule Pretex.Repo.Migrations.CreateDiscountRules do
+  use Ecto.Migration
+
+  def change do
+    create table(:discount_rules) do
+      add(:name, :string, null: false)
+      add(:condition_type, :string, null: false, default: "min_quantity")
+      add(:min_quantity, :integer, null: false, default: 1)
+      add(:value_type, :string, null: false, default: "percentage")
+      add(:value, :integer, null: false, default: 0)
+      add(:active, :boolean, null: false, default: true)
+      add(:description, :string)
+
+      add(:event_id, references(:events, on_delete: :delete_all), null: false)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create(index(:discount_rules, [:event_id]))
+    create(index(:discount_rules, [:event_id, :active]))
+  end
+end

--- a/pretex/priv/repo/migrations/20260319270002_create_discount_rule_items.exs
+++ b/pretex/priv/repo/migrations/20260319270002_create_discount_rule_items.exs
@@ -1,0 +1,17 @@
+defmodule Pretex.Repo.Migrations.CreateDiscountRuleItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:discount_rule_items) do
+      add(:discount_rule_id, references(:discount_rules, on_delete: :delete_all), null: false)
+      add(:item_id, references(:items, on_delete: :delete_all))
+      add(:item_variation_id, references(:item_variations, on_delete: :delete_all))
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create(index(:discount_rule_items, [:discount_rule_id]))
+    create(index(:discount_rule_items, [:item_id]))
+    create(index(:discount_rule_items, [:item_variation_id]))
+  end
+end

--- a/pretex/priv/repo/migrations/20260319270003_create_order_discounts.exs
+++ b/pretex/priv/repo/migrations/20260319270003_create_order_discounts.exs
@@ -1,0 +1,20 @@
+defmodule Pretex.Repo.Migrations.CreateOrderDiscounts do
+  use Ecto.Migration
+
+  def change do
+    create table(:order_discounts) do
+      add(:name, :string, null: false)
+      add(:discount_cents, :integer, null: false, default: 0)
+      add(:value_type, :string)
+      add(:value, :integer, default: 0)
+
+      add(:order_id, references(:orders, on_delete: :delete_all), null: false)
+      add(:discount_rule_id, references(:discount_rules, on_delete: :nilify_all))
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create(index(:order_discounts, [:order_id]))
+    create(index(:order_discounts, [:discount_rule_id]))
+  end
+end

--- a/pretex/priv/repo/migrations/20260319280001_create_gift_cards.exs
+++ b/pretex/priv/repo/migrations/20260319280001_create_gift_cards.exs
@@ -1,0 +1,22 @@
+defmodule Pretex.Repo.Migrations.CreateGiftCards do
+  use Ecto.Migration
+
+  def change do
+    create table(:gift_cards) do
+      add(:code, :string, null: false)
+      add(:balance_cents, :integer, null: false, default: 0)
+      add(:initial_balance_cents, :integer, null: false, default: 0)
+      add(:expires_at, :utc_datetime)
+      add(:active, :boolean, null: false, default: true)
+      add(:note, :string)
+      add(:organization_id, references(:organizations, on_delete: :delete_all), null: false)
+      add(:source_order_id, references(:orders, on_delete: :nilify_all))
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create(unique_index(:gift_cards, [:code], name: :gift_cards_code_index))
+    create(index(:gift_cards, [:organization_id]))
+    create(index(:gift_cards, [:source_order_id]))
+  end
+end

--- a/pretex/priv/repo/migrations/20260319280002_create_gift_card_redemptions.exs
+++ b/pretex/priv/repo/migrations/20260319280002_create_gift_card_redemptions.exs
@@ -1,0 +1,18 @@
+defmodule Pretex.Repo.Migrations.CreateGiftCardRedemptions do
+  use Ecto.Migration
+
+  def change do
+    create table(:gift_card_redemptions) do
+      add(:amount_cents, :integer, null: false, default: 0)
+      add(:kind, :string, null: false, default: "debit")
+      add(:note, :string)
+      add(:gift_card_id, references(:gift_cards, on_delete: :delete_all), null: false)
+      add(:order_id, references(:orders, on_delete: :nilify_all))
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create(index(:gift_card_redemptions, [:gift_card_id]))
+    create(index(:gift_card_redemptions, [:order_id]))
+  end
+end

--- a/pretex/test/pretex/discount_order_integration_test.exs
+++ b/pretex/test/pretex/discount_order_integration_test.exs
@@ -1,0 +1,308 @@
+defmodule Pretex.DiscountOrderIntegrationTest do
+  use Pretex.DataCase, async: true
+
+  import Pretex.OrganizationsFixtures
+  import Pretex.EventsFixtures
+  import Pretex.CatalogFixtures
+
+  alias Pretex.Orders
+  alias Pretex.Discounts
+  alias Pretex.Vouchers
+  alias Pretex.Repo
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp cart_with_item(event, price_cents \\ 5000, quantity \\ 1) do
+    item = item_fixture(event, %{price_cents: price_cents})
+    {:ok, cart} = Orders.create_cart(event)
+    {:ok, _cart_item} = Orders.add_to_cart(cart, item, quantity: quantity)
+    Orders.get_cart_by_token(cart.session_token)
+  end
+
+  defp order_attrs(extra \\ %{}) do
+    Map.merge(
+      %{
+        name: "João Silva",
+        email: "joao@example.com",
+        payment_method: "pix"
+      },
+      extra
+    )
+  end
+
+  defp discount_rule_fixture(event, attrs \\ %{}) do
+    base = %{
+      name: "Regra Integração #{System.unique_integer([:positive])}",
+      condition_type: "min_quantity",
+      min_quantity: 1,
+      value_type: "fixed",
+      value: 1000,
+      active: true
+    }
+
+    {:ok, rule} = Discounts.create_discount_rule(event, Enum.into(attrs, base))
+    rule
+  end
+
+  defp voucher_fixture(event, attrs \\ %{}) do
+    base = %{
+      code: "VOUCHER#{System.unique_integer([:positive])}",
+      effect: "fixed_discount",
+      value: 500,
+      active: true
+    }
+
+    {:ok, voucher} = Vouchers.create_voucher(event, Enum.into(attrs, base))
+    voucher
+  end
+
+  # ---------------------------------------------------------------------------
+  # create_order_from_cart/2 with automatic discount
+  # ---------------------------------------------------------------------------
+
+  describe "create_order_from_cart/2 with matching discount rule" do
+    test "reduces order total by the discount amount (fixed)" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      assert order.total_cents == subtotal - 1000
+    end
+
+    test "reduces order total by the discount amount (percentage)" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      # 10% = 1000 basis points
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "percentage",
+          value: 1000
+        })
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+      expected_discount = round(subtotal * 1000 / 10_000)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      assert order.total_cents == subtotal - expected_discount
+    end
+
+    test "inserts an order_discount record" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          name: "Desconto Integração",
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 800
+        })
+
+      cart = cart_with_item(event, 5000)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      discount =
+        Repo.get_by(Pretex.Discounts.OrderDiscount, order_id: order.id)
+
+      assert discount != nil
+      assert discount.discount_cents == 800
+      assert discount.name == "Desconto Integração"
+    end
+
+    test "selects the best (highest) discount when multiple rules match" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      # Small: 5% of 5000 = 250 cents
+      _rule_small =
+        discount_rule_fixture(event, %{
+          name: "Pequeno",
+          min_quantity: 1,
+          value_type: "percentage",
+          value: 500
+        })
+
+      # Big: fixed 1500 cents
+      _rule_big =
+        discount_rule_fixture(event, %{
+          name: "Grande",
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 1500
+        })
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      # The big (1500) discount should have been applied
+      assert order.total_cents == subtotal - 1500
+
+      discount = Repo.get_by!(Pretex.Discounts.OrderDiscount, order_id: order.id)
+      assert discount.discount_cents == 1500
+      assert discount.name == "Grande"
+    end
+
+    test "order total never goes below zero even with a huge fixed discount" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 999_999
+        })
+
+      cart = cart_with_item(event, 500)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      assert order.total_cents >= 0
+    end
+  end
+
+  describe "create_order_from_cart/2 with non-matching rule" do
+    test "leaves total unchanged when condition is not met" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      # Requires 10 items, cart has only 1
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 10,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      assert order.total_cents == subtotal
+
+      refute Repo.get_by(Pretex.Discounts.OrderDiscount, order_id: order.id)
+    end
+
+    test "leaves total unchanged when event has no discount rules" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      assert order.total_cents == subtotal
+    end
+  end
+
+  describe "create_order_from_cart/2 with both discount and voucher" do
+    test "applies discount first, then voucher on the discounted price (both reduce total)" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      # Automatic discount: fixed R$10 (1000 cents)
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      # Voucher: fixed R$5 (500 cents)
+      _voucher = voucher_fixture(event, %{code: "VOUCHER5", effect: "fixed_discount", value: 500})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      # subtotal = 5000
+      # After discount: 5000 - 1000 = 4000
+      # After voucher:  4000 - 500  = 3500
+      assert {:ok, order} =
+               Orders.create_order_from_cart(cart, order_attrs(%{voucher_code: "VOUCHER5"}))
+
+      assert order.total_cents == subtotal - 1000 - 500
+
+      # Verify discount record exists
+      discount = Repo.get_by!(Pretex.Discounts.OrderDiscount, order_id: order.id)
+      assert discount.discount_cents == 1000
+
+      # Verify voucher redemption exists
+      redemption =
+        Repo.get_by!(Pretex.Vouchers.VoucherRedemption, order_id: order.id)
+
+      assert redemption.discount_cents == 500
+    end
+
+    test "discount applies even when voucher is invalid" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      # Use a non-existent voucher code
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{voucher_code: "INVALID_CODE"})
+               )
+
+      # Discount still applied, voucher silently skipped
+      assert order.total_cents == subtotal - 1000
+    end
+
+    test "voucher applies even when no discount rules match" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      # Rule requires 10 items — won't match
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 10,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      _voucher = voucher_fixture(event, %{code: "ONLY5", effect: "fixed_discount", value: 500})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(cart, order_attrs(%{voucher_code: "ONLY5"}))
+
+      # Only voucher applied
+      assert order.total_cents == subtotal - 500
+      refute Repo.get_by(Pretex.Discounts.OrderDiscount, order_id: order.id)
+    end
+  end
+end

--- a/pretex/test/pretex/discounts_test.exs
+++ b/pretex/test/pretex/discounts_test.exs
@@ -1,0 +1,823 @@
+defmodule Pretex.DiscountsTest do
+  use Pretex.DataCase, async: true
+
+  import Pretex.OrganizationsFixtures
+  import Pretex.EventsFixtures
+  import Pretex.CatalogFixtures
+
+  alias Pretex.Discounts
+  alias Pretex.Discounts.DiscountRule
+  alias Pretex.Discounts.OrderDiscount
+  alias Pretex.Orders
+  alias Pretex.Repo
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp discount_rule_fixture(event, attrs \\ %{}) do
+    base = %{
+      name: "Regra Teste #{System.unique_integer([:positive])}",
+      condition_type: "min_quantity",
+      min_quantity: 2,
+      value_type: "percentage",
+      value: 1000,
+      active: true
+    }
+
+    {:ok, rule} = Discounts.create_discount_rule(event, Enum.into(attrs, base))
+    rule
+  end
+
+  defp order_fixture(event, total_cents \\ 10_000) do
+    {:ok, order} =
+      %Pretex.Orders.Order{}
+      |> Ecto.Changeset.change(%{
+        event_id: event.id,
+        status: "pending",
+        total_cents: total_cents,
+        email: "test@example.com",
+        name: "Test User",
+        confirmation_code: "CONF#{System.unique_integer([:positive])}",
+        expires_at:
+          DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+      })
+      |> Repo.insert()
+
+    order
+  end
+
+  defp cart_items_fixture(price_cents \\ 5000, quantity \\ 1) do
+    [
+      %{
+        item_id: System.unique_integer([:positive]),
+        item_variation_id: nil,
+        quantity: quantity,
+        unit_price_cents: price_cents
+      }
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # list_discount_rules/1
+  # ---------------------------------------------------------------------------
+
+  describe "list_discount_rules/1" do
+    test "returns discount rules for the given event" do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Alfa"})
+
+      result = Discounts.list_discount_rules(event)
+
+      assert Enum.any?(result, &(&1.id == rule.id))
+    end
+
+    test "does not return rules for another event" do
+      org = org_fixture()
+      event1 = event_fixture(org)
+      event2 = event_fixture(org)
+
+      _rule = discount_rule_fixture(event1, %{name: "Regra do Evento 1"})
+
+      result = Discounts.list_discount_rules(event2)
+
+      assert result == []
+    end
+
+    test "preloads scoped_items" do
+      org = org_fixture()
+      event = event_fixture(org)
+      _rule = discount_rule_fixture(event)
+
+      [rule] = Discounts.list_discount_rules(event)
+
+      assert is_list(rule.scoped_items)
+    end
+
+    test "orders by name asc" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      discount_rule_fixture(event, %{name: "Zeta"})
+      discount_rule_fixture(event, %{name: "Alpha"})
+      discount_rule_fixture(event, %{name: "Meso"})
+
+      result = Discounts.list_discount_rules(event)
+      names = Enum.map(result, & &1.name)
+
+      assert names == Enum.sort(names)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_discount_rule!/1
+  # ---------------------------------------------------------------------------
+
+  describe "get_discount_rule!/1" do
+    test "returns rule by id with scoped_items preloaded" do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event)
+
+      fetched = Discounts.get_discount_rule!(rule.id)
+
+      assert fetched.id == rule.id
+      assert is_list(fetched.scoped_items)
+    end
+
+    test "raises when not found" do
+      assert_raise Ecto.NoResultsError, fn ->
+        Discounts.get_discount_rule!(0)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # create_discount_rule/2
+  # ---------------------------------------------------------------------------
+
+  describe "create_discount_rule/2" do
+    test "valid attrs creates a rule" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{
+        name: "Desconto Grupo",
+        condition_type: "min_quantity",
+        min_quantity: 3,
+        value_type: "percentage",
+        value: 500,
+        active: true
+      }
+
+      assert {:ok, rule} = Discounts.create_discount_rule(event, attrs)
+      assert rule.name == "Desconto Grupo"
+      assert rule.min_quantity == 3
+      assert rule.value == 500
+      assert rule.event_id == event.id
+    end
+
+    test "creates a fixed discount rule" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{
+        name: "Desconto Fixo R$10",
+        condition_type: "min_quantity",
+        min_quantity: 1,
+        value_type: "fixed",
+        value: 1000
+      }
+
+      assert {:ok, rule} = Discounts.create_discount_rule(event, attrs)
+      assert rule.value_type == "fixed"
+      assert rule.value == 1000
+    end
+
+    test "returns error for negative value" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{
+        name: "Inválido",
+        condition_type: "min_quantity",
+        value_type: "fixed",
+        value: -100
+      }
+
+      assert {:error, changeset} = Discounts.create_discount_rule(event, attrs)
+      assert %{value: [_ | _]} = errors_on(changeset)
+    end
+
+    test "returns error for percentage greater than 10000" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{
+        name: "Percentual Inválido",
+        condition_type: "min_quantity",
+        value_type: "percentage",
+        value: 10_001
+      }
+
+      assert {:error, changeset} = Discounts.create_discount_rule(event, attrs)
+      assert %{value: [_ | _]} = errors_on(changeset)
+    end
+
+    test "returns error for invalid condition_type" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{
+        name: "Inválido",
+        condition_type: "unknown",
+        value_type: "fixed",
+        value: 100
+      }
+
+      assert {:error, changeset} = Discounts.create_discount_rule(event, attrs)
+      assert %{condition_type: [_ | _]} = errors_on(changeset)
+    end
+
+    test "returns error for name shorter than 2 chars" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{name: "A", condition_type: "min_quantity", value_type: "fixed", value: 100}
+
+      assert {:error, changeset} = Discounts.create_discount_rule(event, attrs)
+      assert %{name: [_ | _]} = errors_on(changeset)
+    end
+
+    test "percentage exactly 10000 is valid (100%)" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      attrs = %{
+        name: "100 porcento",
+        condition_type: "min_quantity",
+        value_type: "percentage",
+        value: 10_000
+      }
+
+      assert {:ok, rule} = Discounts.create_discount_rule(event, attrs)
+      assert rule.value == 10_000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # update_discount_rule/2
+  # ---------------------------------------------------------------------------
+
+  describe "update_discount_rule/2" do
+    test "updates fields" do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Original", value: 500})
+
+      assert {:ok, updated} =
+               Discounts.update_discount_rule(rule, %{name: "Atualizado", value: 1500})
+
+      assert updated.name == "Atualizado"
+      assert updated.value == 1500
+    end
+
+    test "returns error for invalid attrs" do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event)
+
+      assert {:error, changeset} = Discounts.update_discount_rule(rule, %{value: -1})
+      assert %{value: [_ | _]} = errors_on(changeset)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # delete_discount_rule/1
+  # ---------------------------------------------------------------------------
+
+  describe "delete_discount_rule/1" do
+    test "removes the rule" do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event)
+
+      assert {:ok, _} = Discounts.delete_discount_rule(rule)
+      assert_raise Ecto.NoResultsError, fn -> Discounts.get_discount_rule!(rule.id) end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # change_discount_rule/2
+  # ---------------------------------------------------------------------------
+
+  describe "change_discount_rule/2" do
+    test "returns a changeset" do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event)
+
+      changeset = Discounts.change_discount_rule(rule, %{name: "Novo Nome"})
+      assert %Ecto.Changeset{} = changeset
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # evaluate_cart/2
+  # ---------------------------------------------------------------------------
+
+  describe "evaluate_cart/2 with min_quantity rule (no scoped items)" do
+    test "matching cart returns discount entry" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{min_quantity: 2, value_type: "percentage", value: 1000})
+
+      cart_items = [
+        %{item_id: 1, item_variation_id: nil, quantity: 2, unit_price_cents: 5000},
+        %{item_id: 2, item_variation_id: nil, quantity: 1, unit_price_cents: 3000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert length(results) == 1
+      [entry] = results
+      assert entry.discount_cents > 0
+    end
+
+    test "non-matching cart (quantity too low) returns empty list" do
+      org = org_fixture()
+      event = event_fixture(org)
+      _rule = discount_rule_fixture(event, %{min_quantity: 5, value_type: "fixed", value: 500})
+
+      cart_items = [
+        %{item_id: 1, item_variation_id: nil, quantity: 2, unit_price_cents: 5000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert results == []
+    end
+
+    test "exactly matching min_quantity triggers the discount" do
+      org = org_fixture()
+      event = event_fixture(org)
+      _rule = discount_rule_fixture(event, %{min_quantity: 3, value_type: "fixed", value: 1000})
+
+      cart_items = [
+        %{item_id: 1, item_variation_id: nil, quantity: 3, unit_price_cents: 5000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert length(results) == 1
+    end
+
+    test "inactive rules are not evaluated" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 100,
+          active: false
+        })
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 5, unit_price_cents: 5000}]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert results == []
+    end
+  end
+
+  describe "evaluate_cart/2 with scoped min_quantity (only counts scoped items)" do
+    test "only counts cart items whose item_id is in scoped_items" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+
+      {:ok, rule} =
+        Discounts.create_discount_rule(event, %{
+          name: "Scoped Min Qty",
+          condition_type: "min_quantity",
+          min_quantity: 2,
+          value_type: "fixed",
+          value: 500
+        })
+
+      # Add scoped item directly
+      %Pretex.Discounts.DiscountRuleItem{}
+      |> Pretex.Discounts.DiscountRuleItem.changeset(%{
+        discount_rule_id: rule.id,
+        item_id: item.id
+      })
+      |> Repo.insert!()
+
+      # The scoped item has quantity 1 (not enough) but total cart has 3
+      cart_items = [
+        %{item_id: item.id, item_variation_id: nil, quantity: 1, unit_price_cents: 5000},
+        %{item_id: item.id + 999, item_variation_id: nil, quantity: 2, unit_price_cents: 3000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      # Should NOT match because only item.id counts and it has qty=1 < min_quantity=2
+      assert results == []
+    end
+
+    test "matches when scoped item quantity meets threshold" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+
+      {:ok, rule} =
+        Discounts.create_discount_rule(event, %{
+          name: "Scoped Min Qty Match",
+          condition_type: "min_quantity",
+          min_quantity: 2,
+          value_type: "fixed",
+          value: 500
+        })
+
+      %Pretex.Discounts.DiscountRuleItem{}
+      |> Pretex.Discounts.DiscountRuleItem.changeset(%{
+        discount_rule_id: rule.id,
+        item_id: item.id
+      })
+      |> Repo.insert!()
+
+      cart_items = [
+        %{item_id: item.id, item_variation_id: nil, quantity: 3, unit_price_cents: 5000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert length(results) == 1
+      [entry] = results
+      assert entry.rule.id == rule.id
+    end
+  end
+
+  describe "evaluate_cart/2 with item_combo rule" do
+    test "matching cart (all required items present) returns discount entry" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item_a = item_fixture(event)
+      item_b = item_fixture(event)
+
+      {:ok, rule} =
+        Discounts.create_discount_rule(event, %{
+          name: "Combo AB",
+          condition_type: "item_combo",
+          value_type: "percentage",
+          value: 1000
+        })
+
+      Repo.insert!(%Pretex.Discounts.DiscountRuleItem{
+        discount_rule_id: rule.id,
+        item_id: item_a.id
+      })
+
+      Repo.insert!(%Pretex.Discounts.DiscountRuleItem{
+        discount_rule_id: rule.id,
+        item_id: item_b.id
+      })
+
+      cart_items = [
+        %{item_id: item_a.id, item_variation_id: nil, quantity: 1, unit_price_cents: 5000},
+        %{item_id: item_b.id, item_variation_id: nil, quantity: 1, unit_price_cents: 3000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert length(results) == 1
+      [entry] = results
+      assert entry.rule.id == rule.id
+    end
+
+    test "missing one required item returns empty list" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item_a = item_fixture(event)
+      item_b = item_fixture(event)
+
+      {:ok, rule} =
+        Discounts.create_discount_rule(event, %{
+          name: "Combo AB incompleto",
+          condition_type: "item_combo",
+          value_type: "fixed",
+          value: 500
+        })
+
+      Repo.insert!(%Pretex.Discounts.DiscountRuleItem{
+        discount_rule_id: rule.id,
+        item_id: item_a.id
+      })
+
+      Repo.insert!(%Pretex.Discounts.DiscountRuleItem{
+        discount_rule_id: rule.id,
+        item_id: item_b.id
+      })
+
+      # Only item_a in cart, item_b missing
+      cart_items = [
+        %{item_id: item_a.id, item_variation_id: nil, quantity: 1, unit_price_cents: 5000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert results == []
+    end
+
+    test "item_combo with no scoped items never matches" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          condition_type: "item_combo",
+          value_type: "fixed",
+          value: 500
+        })
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 5, unit_price_cents: 5000}]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert results == []
+    end
+  end
+
+  describe "evaluate_cart/2 with multiple rules" do
+    test "returns all matching rules sorted desc by discount_cents" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      # Rule giving ~10% off R$50 = R$5 (500 cents)
+      _rule_small =
+        discount_rule_fixture(event, %{
+          name: "Pequeno",
+          min_quantity: 1,
+          value_type: "percentage",
+          value: 1000
+        })
+
+      # Rule giving fixed R$10 (1000 cents)
+      _rule_big =
+        discount_rule_fixture(event, %{
+          name: "Grande",
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      cart_items = [
+        %{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 5000}
+      ]
+
+      results = Discounts.evaluate_cart(event.id, cart_items)
+
+      assert length(results) == 2
+      [first, second] = results
+      assert first.discount_cents >= second.discount_cents
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # best_discount/2
+  # ---------------------------------------------------------------------------
+
+  describe "best_discount/2" do
+    test "returns highest discount when multiple rules match" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      # 10% of 10000 = 1000 cents
+      _rule_pct =
+        discount_rule_fixture(event, %{
+          name: "Percentual",
+          min_quantity: 1,
+          value_type: "percentage",
+          value: 1000
+        })
+
+      # Fixed 2000 cents
+      _rule_fixed =
+        discount_rule_fixture(event, %{
+          name: "Fixo",
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 2000
+        })
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 10_000}]
+
+      assert {:ok, best} = Discounts.best_discount(event.id, cart_items)
+      assert best.discount_cents == 2000
+      assert best.rule.name == "Fixo"
+    end
+
+    test "returns :no_discount when no rules match" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 10,
+          value_type: "fixed",
+          value: 500
+        })
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 5000}]
+
+      assert {:error, :no_discount} = Discounts.best_discount(event.id, cart_items)
+    end
+
+    test "returns :no_discount when event has no rules" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 5000}]
+
+      assert {:error, :no_discount} = Discounts.best_discount(event.id, cart_items)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # compute_discount_for_cart/2
+  # ---------------------------------------------------------------------------
+
+  describe "compute_discount_for_cart/2" do
+    test "returns 0 when no rules match" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 5000}]
+
+      assert Discounts.compute_discount_for_cart(event.id, cart_items) == 0
+    end
+
+    test "returns correct cents when a rule matches (percentage)" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "percentage",
+          value: 500
+        })
+
+      # 5% of 10000 = 500
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 10_000}]
+
+      assert Discounts.compute_discount_for_cart(event.id, cart_items) == 500
+    end
+
+    test "returns correct cents when a rule matches (fixed)" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 750
+        })
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 5000}]
+
+      assert Discounts.compute_discount_for_cart(event.id, cart_items) == 750
+    end
+
+    test "fixed discount is capped at subtotal" do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 99_999
+        })
+
+      cart_items = [%{item_id: 1, item_variation_id: nil, quantity: 1, unit_price_cents: 1000}]
+
+      # discount cannot exceed subtotal
+      assert Discounts.compute_discount_for_cart(event.id, cart_items) == 1000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # apply_best_discount/2
+  # ---------------------------------------------------------------------------
+
+  describe "apply_best_discount/2" do
+    test "inserts OrderDiscount and updates order.total_cents" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, %{price_cents: 5000})
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      order = order_fixture(event, 5000)
+
+      # Build a fake order_items list (mimicking what preload returns)
+      order_item = %Pretex.Orders.OrderItem{
+        order_id: order.id,
+        item_id: item.id,
+        item_variation_id: nil,
+        item: item,
+        item_variation: nil,
+        quantity: 1,
+        unit_price_cents: 5000
+      }
+
+      order_with_items = %{order | order_items: [order_item]}
+
+      assert {:ok, updated_order} = Discounts.apply_best_discount(order_with_items, event.id)
+      assert updated_order.total_cents == 4000
+
+      discount = Repo.get_by!(OrderDiscount, order_id: order.id)
+      assert discount.discount_cents == 1000
+    end
+
+    test "caps discount so total does not go below zero" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, %{price_cents: 500})
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 99_999
+        })
+
+      order = order_fixture(event, 500)
+
+      order_item = %Pretex.Orders.OrderItem{
+        order_id: order.id,
+        item_id: item.id,
+        item_variation_id: nil,
+        item: item,
+        item_variation: nil,
+        quantity: 1,
+        unit_price_cents: 500
+      }
+
+      order_with_items = %{order | order_items: [order_item]}
+
+      assert {:ok, updated_order} = Discounts.apply_best_discount(order_with_items, event.id)
+      assert updated_order.total_cents == 0
+
+      discount = Repo.get_by!(OrderDiscount, order_id: order.id)
+      assert discount.discount_cents == 500
+    end
+
+    test "returns unchanged order when no rules match" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, %{price_cents: 5000})
+
+      _rule =
+        discount_rule_fixture(event, %{
+          min_quantity: 100,
+          value_type: "fixed",
+          value: 1000
+        })
+
+      order = order_fixture(event, 5000)
+
+      order_item = %Pretex.Orders.OrderItem{
+        order_id: order.id,
+        item_id: item.id,
+        item_variation_id: nil,
+        item: item,
+        item_variation: nil,
+        quantity: 1,
+        unit_price_cents: 5000
+      }
+
+      order_with_items = %{order | order_items: [order_item]}
+
+      assert {:ok, unchanged_order} = Discounts.apply_best_discount(order_with_items, event.id)
+      assert unchanged_order.total_cents == 5000
+
+      refute Repo.get_by(OrderDiscount, order_id: order.id)
+    end
+
+    test "returns unchanged order when event has no discount rules" do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, %{price_cents: 5000})
+
+      order = order_fixture(event, 5000)
+
+      order_item = %Pretex.Orders.OrderItem{
+        order_id: order.id,
+        item_id: item.id,
+        item_variation_id: nil,
+        item: item,
+        item_variation: nil,
+        quantity: 1,
+        unit_price_cents: 5000
+      }
+
+      order_with_items = %{order | order_items: [order_item]}
+
+      assert {:ok, unchanged_order} = Discounts.apply_best_discount(order_with_items, event.id)
+      assert unchanged_order.total_cents == 5000
+    end
+  end
+end

--- a/pretex/test/pretex/gift_card_order_integration_test.exs
+++ b/pretex/test/pretex/gift_card_order_integration_test.exs
@@ -1,0 +1,494 @@
+defmodule Pretex.GiftCardOrderIntegrationTest do
+  use Pretex.DataCase, async: true
+
+  import Pretex.OrganizationsFixtures
+  import Pretex.EventsFixtures
+  import Pretex.CatalogFixtures
+
+  alias Pretex.Orders
+  alias Pretex.GiftCards
+  alias Pretex.Repo
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp cart_with_item(event, price_cents \\ 5000) do
+    item = item_fixture(event, %{price_cents: price_cents})
+    {:ok, cart} = Orders.create_cart(event)
+    {:ok, _cart_item} = Orders.add_to_cart(cart, item, quantity: 1)
+    Orders.get_cart_by_token(cart.session_token)
+  end
+
+  defp order_attrs(extra \\ %{}) do
+    Map.merge(
+      %{
+        name: "João Silva",
+        email: "joao@example.com",
+        payment_method: "pix"
+      },
+      extra
+    )
+  end
+
+  defp gift_card_fixture(org, attrs \\ %{}) do
+    base = %{
+      code: "GC-TEST#{System.unique_integer([:positive])}",
+      balance_cents: 5000,
+      active: true
+    }
+
+    {:ok, gc} = GiftCards.create_gift_card(org, Enum.into(attrs, base))
+    gc
+  end
+
+  # ---------------------------------------------------------------------------
+  # create_order_from_cart/2 with gift_card_code
+  # ---------------------------------------------------------------------------
+
+  describe "create_order_from_cart/2 with gift_card_code" do
+    test "deducts gift card balance from order total" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-DEDUCT01", balance_cents: 2000})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert order.total_cents == subtotal - 2000
+    end
+
+    test "reduces gift card balance after redemption" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-BALANCE01", balance_cents: 2000})
+
+      cart = cart_with_item(event, 5000)
+
+      assert {:ok, _order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      updated_gc = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert updated_gc.balance_cents == 0
+    end
+
+    test "inserts a debit gift card redemption record" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-REDEM01", balance_cents: 3000})
+
+      cart = cart_with_item(event, 5000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      redemption = GiftCards.get_debit_redemption_for_order(order.id)
+
+      assert redemption != nil
+      assert redemption.order_id == order.id
+      assert redemption.amount_cents == 3000
+      assert redemption.kind == "debit"
+    end
+
+    test "partial redemption: order total greater than gift card balance" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-PARTIAL01", balance_cents: 1500})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      # Only card balance deducted, remaining total > 0
+      assert order.total_cents == subtotal - 1500
+      assert order.total_cents > 0
+
+      updated_gc = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert updated_gc.balance_cents == 0
+    end
+
+    test "gift card balance larger than order total clamps to zero" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-LARGE01", balance_cents: 99_999})
+
+      cart = cart_with_item(event, 1000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert order.total_cents == 0
+    end
+
+    test "unused gift card balance remains on card after order" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-REMAIN01", balance_cents: 10_000})
+
+      cart = cart_with_item(event, 3000)
+
+      assert {:ok, _order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      updated_gc = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      # 10000 - 3000 = 7000 remaining
+      assert updated_gc.balance_cents == 7000
+    end
+
+    test "gift card from wrong organization is silently skipped" do
+      org1 = org_fixture()
+      org2 = org_fixture()
+      event = published_event_fixture(org2)
+      gc = gift_card_fixture(org1, %{code: "GC-WRONGORG1", balance_cents: 5000})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      # No deduction — wrong org
+      assert order.total_cents == subtotal
+    end
+
+    test "no gift card redemption record when wrong org card is used" do
+      org1 = org_fixture()
+      org2 = org_fixture()
+      event = published_event_fixture(org2)
+      gc = gift_card_fixture(org1, %{code: "GC-WRONGORG2", balance_cents: 5000})
+
+      cart = cart_with_item(event, 5000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert GiftCards.get_debit_redemption_for_order(order.id) == nil
+    end
+
+    test "silently skips when gift_card_code is nil" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+      assert order.total_cents == subtotal
+    end
+
+    test "silently skips when gift_card_code is an empty string" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(cart, order_attrs(%{gift_card_code: ""}))
+
+      assert order.total_cents == subtotal
+    end
+
+    test "silently skips when gift card code does not exist" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: "GC-DOESNOTEXIST"})
+               )
+
+      assert order.total_cents == subtotal
+    end
+
+    test "silently skips when gift card is inactive" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-INACTIVE01", balance_cents: 5000, active: false})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert order.total_cents == subtotal
+    end
+
+    test "silently skips when gift card is expired" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          code: "GC-EXPIRED01",
+          balance_cents: 5000,
+          expires_at: past
+        })
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert order.total_cents == subtotal
+    end
+
+    test "silently skips when gift card balance is zero" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-EMPTY01", balance_cents: 0})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert order.total_cents == subtotal
+    end
+
+    test "works with string-key attrs map" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-STRKEY01", balance_cents: 2000})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      string_attrs = %{
+        "name" => "João Silva",
+        "email" => "joao@example.com",
+        "payment_method" => "pix",
+        "gift_card_code" => gc.code
+      }
+
+      assert {:ok, order} = Orders.create_order_from_cart(cart, string_attrs)
+      assert order.total_cents == subtotal - 2000
+    end
+
+    test "gift card applied case-insensitively" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-CASECI01", balance_cents: 1000})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: "gc-caseci01"})
+               )
+
+      assert order.total_cents == subtotal - 1000
+    end
+
+    test "preloads gift_card_redemptions on the returned order" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-PRELOAD1", balance_cents: 2000})
+
+      cart = cart_with_item(event, 5000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert is_list(order.gift_card_redemptions)
+      assert length(order.gift_card_redemptions) == 1
+    end
+
+    test "fees still applied when gift card is also applied" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+
+      {:ok, _rule} =
+        Pretex.Fees.create_fee_rule(event, %{
+          name: "Taxa de Serviço",
+          fee_type: "service",
+          value_type: "fixed",
+          value: 200,
+          apply_mode: "automatic",
+          active: true
+        })
+
+      gc = gift_card_fixture(org, %{code: "GC-WITHFEE1", balance_cents: 1000})
+
+      cart = cart_with_item(event, 5000)
+      subtotal = Orders.cart_total(cart)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      # total = subtotal + fee - gc = 5000 + 200 - 1000 = 4200
+      assert order.total_cents == subtotal + 200 - 1000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # cancel_order/1 with gift card redemption
+  # ---------------------------------------------------------------------------
+
+  describe "cancel_order/1 with gift card redemption" do
+    test "restores gift card balance when order with gift card is cancelled" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-CANCEL01", balance_cents: 5000})
+
+      cart = cart_with_item(event, 3000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      # Verify deduction happened
+      gc_after_order = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert gc_after_order.balance_cents == 2000
+
+      # Cancel the order
+      assert {:ok, _cancelled} = Orders.cancel_order(order)
+
+      # Balance should be restored
+      gc_after_cancel = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert gc_after_cancel.balance_cents == 5000
+    end
+
+    test "inserts a credit redemption when order is cancelled" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-CANCEL02", balance_cents: 5000})
+
+      cart = cart_with_item(event, 3000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      Orders.cancel_order(order)
+
+      credit_redemption =
+        Pretex.GiftCards.GiftCardRedemption
+        |> Ecto.Query.where(gift_card_id: ^gc.id, kind: "credit")
+        |> Repo.one()
+
+      assert credit_redemption != nil
+      assert credit_redemption.amount_cents == 3000
+    end
+
+    test "does not touch gift card when order had no gift card redemption" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-NOCANCEL1", balance_cents: 5000})
+
+      cart = cart_with_item(event, 3000)
+
+      # Place order WITHOUT gift card
+      assert {:ok, order} = Orders.create_order_from_cart(cart, order_attrs())
+
+      # Cancel it
+      assert {:ok, _cancelled} = Orders.cancel_order(order)
+
+      # Gift card balance should be untouched
+      gc_after = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert gc_after.balance_cents == 5000
+    end
+
+    test "marks the order as cancelled" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-CANCEL03", balance_cents: 5000})
+
+      cart = cart_with_item(event, 3000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      assert {:ok, cancelled} = Orders.cancel_order(order)
+      assert cancelled.status == "cancelled"
+    end
+
+    test "restores partial gift card balance correctly" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      # Card has less than order price — partial redemption
+      gc = gift_card_fixture(org, %{code: "GC-PARTCAN1", balance_cents: 1000})
+
+      cart = cart_with_item(event, 5000)
+
+      assert {:ok, order} =
+               Orders.create_order_from_cart(
+                 cart,
+                 order_attrs(%{gift_card_code: gc.code})
+               )
+
+      # Verify full card was deducted
+      gc_after_order = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert gc_after_order.balance_cents == 0
+
+      # Cancel
+      assert {:ok, _cancelled} = Orders.cancel_order(order)
+
+      # Full 1000 should be restored
+      gc_after_cancel = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert gc_after_cancel.balance_cents == 1000
+    end
+  end
+end

--- a/pretex/test/pretex/gift_cards_test.exs
+++ b/pretex/test/pretex/gift_cards_test.exs
@@ -1,0 +1,707 @@
+defmodule Pretex.GiftCardsTest do
+  use Pretex.DataCase, async: true
+
+  import Pretex.OrganizationsFixtures
+  import Pretex.EventsFixtures
+
+  alias Pretex.GiftCards
+  alias Pretex.GiftCards.GiftCard
+  alias Pretex.GiftCards.GiftCardRedemption
+  alias Pretex.Repo
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp gift_card_fixture(org, attrs \\ %{}) do
+    base = %{
+      code: "GC-TEST#{System.unique_integer([:positive])}",
+      balance_cents: 5000,
+      active: true
+    }
+
+    {:ok, gc} = GiftCards.create_gift_card(org, Enum.into(attrs, base))
+    gc
+  end
+
+  defp order_fixture(event) do
+    {:ok, order} =
+      %Pretex.Orders.Order{}
+      |> Ecto.Changeset.change(%{
+        event_id: event.id,
+        status: "pending",
+        total_cents: 10_000,
+        email: "test@example.com",
+        name: "Test User",
+        confirmation_code: "CONF#{System.unique_integer([:positive])}",
+        expires_at:
+          DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+      })
+      |> Repo.insert()
+
+    order
+  end
+
+  # ---------------------------------------------------------------------------
+  # list_gift_cards/1
+  # ---------------------------------------------------------------------------
+
+  describe "list_gift_cards/1" do
+    test "returns gift cards for the given organization" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      result = GiftCards.list_gift_cards(org)
+
+      assert Enum.any?(result, &(&1.id == gc.id))
+    end
+
+    test "does not return gift cards from other organizations" do
+      org1 = org_fixture()
+      org2 = org_fixture()
+      gc = gift_card_fixture(org1)
+
+      result = GiftCards.list_gift_cards(org2)
+
+      refute Enum.any?(result, &(&1.id == gc.id))
+    end
+
+    test "returns results ordered by inserted_at desc" do
+      org = org_fixture()
+      gc1 = gift_card_fixture(org, %{code: "GC-FIRST"})
+      gc2 = gift_card_fixture(org, %{code: "GC-SECOND"})
+
+      result = GiftCards.list_gift_cards(org)
+      ids = Enum.map(result, & &1.id)
+
+      # Both cards should appear; gc2 has a higher auto-increment ID so it was
+      # inserted after gc1. If they share the same inserted_at second, the
+      # relative order still satisfies "most-recently-inserted first" by ID.
+      assert gc2.id > gc1.id
+      assert Enum.member?(ids, gc1.id)
+      assert Enum.member?(ids, gc2.id)
+    end
+
+    test "preloads redemptions" do
+      org = org_fixture()
+      _gc = gift_card_fixture(org)
+
+      [result | _] = GiftCards.list_gift_cards(org)
+
+      assert is_list(result.redemptions)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # create_gift_card/2
+  # ---------------------------------------------------------------------------
+
+  describe "create_gift_card/2" do
+    test "creates a gift card with valid attrs" do
+      org = org_fixture()
+
+      assert {:ok, gc} =
+               GiftCards.create_gift_card(org, %{
+                 code: "GC-ABCD1234",
+                 balance_cents: 5000
+               })
+
+      assert gc.code == "GC-ABCD1234"
+      assert gc.balance_cents == 5000
+      assert gc.organization_id == org.id
+    end
+
+    test "code is uppercased automatically" do
+      org = org_fixture()
+
+      assert {:ok, gc} =
+               GiftCards.create_gift_card(org, %{
+                 code: "gc-lowercase",
+                 balance_cents: 1000
+               })
+
+      assert gc.code == "GC-LOWERCASE"
+    end
+
+    test "sets initial_balance_cents equal to balance_cents when not provided" do
+      org = org_fixture()
+
+      assert {:ok, gc} =
+               GiftCards.create_gift_card(org, %{
+                 code: "GC-IBALANCE",
+                 balance_cents: 7500
+               })
+
+      assert gc.initial_balance_cents == 7500
+    end
+
+    test "respects explicit initial_balance_cents when provided" do
+      org = org_fixture()
+
+      assert {:ok, gc} =
+               GiftCards.create_gift_card(org, %{
+                 code: "GC-EXPLICIT",
+                 balance_cents: 3000,
+                 initial_balance_cents: 10_000
+               })
+
+      assert gc.initial_balance_cents == 10_000
+      assert gc.balance_cents == 3000
+    end
+
+    test "duplicate code returns error changeset" do
+      org = org_fixture()
+      _gc1 = gift_card_fixture(org, %{code: "GC-DUPCODE"})
+
+      assert {:error, changeset} =
+               GiftCards.create_gift_card(org, %{
+                 code: "GC-DUPCODE",
+                 balance_cents: 1000
+               })
+
+      assert %{code: [_ | _]} = errors_on(changeset)
+    end
+
+    test "negative balance returns error changeset" do
+      org = org_fixture()
+
+      assert {:error, changeset} =
+               GiftCards.create_gift_card(org, %{
+                 code: "GC-NEGBAL",
+                 balance_cents: -100
+               })
+
+      assert %{balance_cents: [_ | _]} = errors_on(changeset)
+    end
+
+    test "missing code returns error changeset" do
+      org = org_fixture()
+
+      assert {:error, changeset} =
+               GiftCards.create_gift_card(org, %{balance_cents: 1000})
+
+      assert %{code: [_ | _]} = errors_on(changeset)
+    end
+
+    test "sets active to true by default" do
+      org = org_fixture()
+
+      assert {:ok, gc} =
+               GiftCards.create_gift_card(org, %{
+                 code: "GC-ACTIVE",
+                 balance_cents: 1000
+               })
+
+      assert gc.active == true
+    end
+
+    test "string-key attrs work correctly" do
+      org = org_fixture()
+
+      assert {:ok, gc} =
+               GiftCards.create_gift_card(org, %{
+                 "code" => "GC-STRKEYS",
+                 "balance_cents" => 2000
+               })
+
+      assert gc.balance_cents == 2000
+      assert gc.initial_balance_cents == 2000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # update_gift_card/2
+  # ---------------------------------------------------------------------------
+
+  describe "update_gift_card/2" do
+    test "updates fields successfully" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 5000, note: "original"})
+
+      assert {:ok, updated} =
+               GiftCards.update_gift_card(gc, %{balance_cents: 3000, note: "updated"})
+
+      assert updated.balance_cents == 3000
+      assert updated.note == "updated"
+    end
+
+    test "returns error changeset for invalid attrs" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      assert {:error, changeset} = GiftCards.update_gift_card(gc, %{balance_cents: -1})
+
+      assert %{balance_cents: [_ | _]} = errors_on(changeset)
+    end
+
+    test "can deactivate a gift card" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{active: true})
+
+      assert {:ok, updated} = GiftCards.update_gift_card(gc, %{active: false})
+      assert updated.active == false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # delete_gift_card/1
+  # ---------------------------------------------------------------------------
+
+  describe "delete_gift_card/1" do
+    test "removes the gift card" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      assert {:ok, _} = GiftCards.delete_gift_card(gc)
+      assert Repo.get(GiftCard, gc.id) == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # top_up/2
+  # ---------------------------------------------------------------------------
+
+  describe "top_up/2" do
+    test "increases the gift card balance" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      assert {:ok, updated} = GiftCards.top_up(gc, 2000)
+      assert updated.balance_cents == 7000
+    end
+
+    test "inserts a credit redemption with note 'Top-up'" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      assert {:ok, _updated} = GiftCards.top_up(gc, 1500)
+
+      redemption =
+        GiftCardRedemption
+        |> Pretex.Repo.get_by(gift_card_id: gc.id, kind: "credit")
+
+      assert redemption != nil
+      assert redemption.amount_cents == 1500
+      assert redemption.note == "Top-up"
+    end
+
+    test "returns error for zero amount" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      assert {:error, _} = GiftCards.top_up(gc, 0)
+    end
+
+    test "returns error for negative amount" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      assert {:error, _} = GiftCards.top_up(gc, -100)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_gift_card_by_code/1
+  # ---------------------------------------------------------------------------
+
+  describe "get_gift_card_by_code/1" do
+    test "finds a gift card by code" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-FINDME"})
+
+      assert {:ok, found} = GiftCards.get_gift_card_by_code("GC-FINDME")
+      assert found.id == gc.id
+    end
+
+    test "finds a gift card case-insensitively" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-CASEFIND"})
+
+      assert {:ok, found} = GiftCards.get_gift_card_by_code("gc-casefind")
+      assert found.id == gc.id
+    end
+
+    test "trims whitespace before lookup" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TRIMME"})
+
+      assert {:ok, found} = GiftCards.get_gift_card_by_code("  GC-TRIMME  ")
+      assert found.id == gc.id
+    end
+
+    test "returns error for unknown code" do
+      assert {:error, :not_found} = GiftCards.get_gift_card_by_code("GC-UNKNOWN")
+    end
+
+    test "returns error for nil" do
+      assert {:error, :not_found} = GiftCards.get_gift_card_by_code(nil)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # validate_for_checkout/2
+  # ---------------------------------------------------------------------------
+
+  describe "validate_for_checkout/2" do
+    test "returns ok for a valid, active, non-expired gift card with balance" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 1000, active: true})
+
+      assert {:ok, found} = GiftCards.validate_for_checkout(gc.code, org.id)
+      assert found.id == gc.id
+    end
+
+    test "returns :not_found for unknown code" do
+      org = org_fixture()
+
+      assert {:error, :not_found} =
+               GiftCards.validate_for_checkout("GC-DOESNOTEXIST", org.id)
+    end
+
+    test "returns :wrong_organization for a gift card from a different org" do
+      org1 = org_fixture()
+      org2 = org_fixture()
+      gc = gift_card_fixture(org1, %{balance_cents: 1000, active: true})
+
+      assert {:error, :wrong_organization} =
+               GiftCards.validate_for_checkout(gc.code, org2.id)
+    end
+
+    test "returns :expired for a gift card with past expires_at" do
+      org = org_fixture()
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          balance_cents: 1000,
+          active: true,
+          expires_at: past
+        })
+
+      assert {:error, :expired} = GiftCards.validate_for_checkout(gc.code, org.id)
+    end
+
+    test "returns :ok for a gift card with future expires_at" do
+      org = org_fixture()
+
+      future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          balance_cents: 1000,
+          active: true,
+          expires_at: future
+        })
+
+      assert {:ok, _} = GiftCards.validate_for_checkout(gc.code, org.id)
+    end
+
+    test "returns :empty for a gift card with zero balance" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 0, active: true})
+
+      assert {:error, :empty} = GiftCards.validate_for_checkout(gc.code, org.id)
+    end
+
+    test "returns :inactive for an inactive gift card" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 1000, active: false})
+
+      assert {:error, :inactive} = GiftCards.validate_for_checkout(gc.code, org.id)
+    end
+
+    test "checks organization before expiry" do
+      org1 = org_fixture()
+      org2 = org_fixture()
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org1, %{
+          balance_cents: 1000,
+          active: true,
+          expires_at: past
+        })
+
+      # wrong org takes precedence
+      assert {:error, :wrong_organization} =
+               GiftCards.validate_for_checkout(gc.code, org2.id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # redeem/3
+  # ---------------------------------------------------------------------------
+
+  describe "redeem/3" do
+    test "deducts full requested amount when balance is sufficient" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 10_000})
+
+      assert {:ok, result} = GiftCards.redeem(gc, order, 3000)
+      assert result.deduction_cents == 3000
+
+      updated_gc = Repo.get!(GiftCard, gc.id)
+      assert updated_gc.balance_cents == 7000
+    end
+
+    test "deducts only available balance when order total exceeds balance (partial)" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      assert {:ok, result} = GiftCards.redeem(gc, order, 5000)
+      assert result.deduction_cents == 2000
+
+      updated_gc = Repo.get!(GiftCard, gc.id)
+      assert updated_gc.balance_cents == 0
+    end
+
+    test "deducts full balance when order total equals balance" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      assert {:ok, result} = GiftCards.redeem(gc, order, 5000)
+      assert result.deduction_cents == 5000
+
+      updated_gc = Repo.get!(GiftCard, gc.id)
+      assert updated_gc.balance_cents == 0
+    end
+
+    test "inserts a debit redemption record" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      assert {:ok, _result} = GiftCards.redeem(gc, order, 2000)
+
+      redemption = Repo.get_by(GiftCardRedemption, gift_card_id: gc.id, kind: "debit")
+      assert redemption != nil
+      assert redemption.amount_cents == 2000
+      assert redemption.order_id == order.id
+    end
+
+    test "returns zero deduction when requested_cents is zero" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      assert {:ok, result} = GiftCards.redeem(gc, order, 0)
+      assert result.deduction_cents == 0
+
+      updated_gc = Repo.get!(GiftCard, gc.id)
+      assert updated_gc.balance_cents == 5000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # restore_balance/3
+  # ---------------------------------------------------------------------------
+
+  describe "restore_balance/3" do
+    test "increases balance for a non-expired card" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 1000})
+
+      assert {:ok, updated} = GiftCards.restore_balance(gc, 2000)
+      assert updated.balance_cents == 3000
+    end
+
+    test "inserts a credit redemption for a non-expired card" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 1000})
+
+      assert {:ok, _updated} = GiftCards.restore_balance(gc, 500)
+
+      redemption = Repo.get_by(GiftCardRedemption, gift_card_id: gc.id, kind: "credit")
+      assert redemption != nil
+      assert redemption.amount_cents == 500
+      assert redemption.note == "Restaurado por reembolso"
+    end
+
+    test "extends expiry by 1 year for an expired card" do
+      org = org_fixture()
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          balance_cents: 500,
+          expires_at: past
+        })
+
+      assert {:ok, updated} = GiftCards.restore_balance(gc, 1000)
+
+      now = DateTime.utc_now()
+      one_year_from_now = DateTime.add(now, 365 * 24 * 3600, :second)
+
+      # Should be within a few seconds of one year from now
+      diff = DateTime.diff(updated.expires_at, one_year_from_now, :second)
+      assert abs(diff) < 10
+    end
+
+    test "inserts credit redemption with extended-expiry note for expired card" do
+      org = org_fixture()
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          balance_cents: 500,
+          expires_at: past
+        })
+
+      assert {:ok, _updated} = GiftCards.restore_balance(gc, 750)
+
+      redemption = Repo.get_by(GiftCardRedemption, gift_card_id: gc.id, kind: "credit")
+      assert redemption != nil
+      assert redemption.note == "Restaurado por reembolso (validade estendida)"
+    end
+
+    test "does not change expiry for a card without expiry" do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{balance_cents: 1000, expires_at: nil})
+
+      assert {:ok, updated} = GiftCards.restore_balance(gc, 500)
+      assert updated.expires_at == nil
+    end
+
+    test "does not change expiry for a future-expiry card" do
+      org = org_fixture()
+
+      future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          balance_cents: 1000,
+          expires_at: future
+        })
+
+      assert {:ok, updated} = GiftCards.restore_balance(gc, 500)
+      assert DateTime.compare(updated.expires_at, future) == :eq
+    end
+
+    test "increases balance for an expired card" do
+      org = org_fixture()
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc =
+        gift_card_fixture(org, %{
+          balance_cents: 500,
+          expires_at: past
+        })
+
+      assert {:ok, updated} = GiftCards.restore_balance(gc, 1000)
+      assert updated.balance_cents == 1500
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_debit_redemption_for_order/1
+  # ---------------------------------------------------------------------------
+
+  describe "get_debit_redemption_for_order/1" do
+    test "returns the debit redemption for an order" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      {:ok, _} = GiftCards.redeem(gc, order, 2000)
+
+      redemption = GiftCards.get_debit_redemption_for_order(order.id)
+
+      assert redemption != nil
+      assert redemption.order_id == order.id
+      assert redemption.kind == "debit"
+      assert redemption.amount_cents == 2000
+    end
+
+    test "preloads the gift_card association" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+      gc = gift_card_fixture(org, %{balance_cents: 5000})
+
+      {:ok, _} = GiftCards.redeem(gc, order, 2000)
+
+      redemption = GiftCards.get_debit_redemption_for_order(order.id)
+
+      assert redemption.gift_card != nil
+      assert redemption.gift_card.id == gc.id
+    end
+
+    test "returns nil when no debit redemption exists for the order" do
+      org = org_fixture()
+      event = event_fixture(org)
+      order = order_fixture(event)
+
+      assert GiftCards.get_debit_redemption_for_order(order.id) == nil
+    end
+
+    test "returns nil for a non-existent order id" do
+      assert GiftCards.get_debit_redemption_for_order(999_999_999) == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # generate_code/0
+  # ---------------------------------------------------------------------------
+
+  describe "generate_code/0" do
+    test "returns a string starting with 'GC-'" do
+      code = GiftCards.generate_code()
+      assert String.starts_with?(code, "GC-")
+    end
+
+    test "returns a code with 8 characters after the prefix" do
+      code = GiftCards.generate_code()
+      suffix = String.slice(code, 3..-1//1)
+      assert String.length(suffix) == 8
+    end
+
+    test "generates different codes on successive calls" do
+      codes = for _ <- 1..10, do: GiftCards.generate_code()
+      unique_codes = Enum.uniq(codes)
+      # Very unlikely to have duplicates in 10 calls
+      assert length(unique_codes) > 1
+    end
+
+    test "generated code is uppercase alphanumeric after prefix" do
+      code = GiftCards.generate_code()
+      suffix = String.slice(code, 3..-1//1)
+      assert suffix =~ ~r/^[A-Z0-9]+$/
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # change_gift_card/2
+  # ---------------------------------------------------------------------------
+
+  describe "change_gift_card/2" do
+    test "returns a changeset" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      changeset = GiftCards.change_gift_card(gc)
+      assert %Ecto.Changeset{} = changeset
+    end
+
+    test "returns a changeset with given attrs applied" do
+      org = org_fixture()
+      gc = gift_card_fixture(org)
+
+      changeset = GiftCards.change_gift_card(gc, %{note: "updated note"})
+      assert Ecto.Changeset.get_change(changeset, :note) == "updated note"
+    end
+  end
+end

--- a/pretex/test/pretex_web/live/admin/discount_live_test.exs
+++ b/pretex/test/pretex_web/live/admin/discount_live_test.exs
@@ -1,0 +1,489 @@
+defmodule PretexWeb.Admin.DiscountLiveTest do
+  use PretexWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Pretex.Events
+  alias Pretex.Organizations
+  alias Pretex.Discounts
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp org_fixture(attrs \\ %{}) do
+    {:ok, org} =
+      attrs
+      |> Enum.into(%{name: "Test Org", slug: "test-org-#{System.unique_integer([:positive])}"})
+      |> Organizations.create_organization()
+
+    org
+  end
+
+  defp event_fixture(org, attrs \\ %{}) do
+    base = %{
+      name: "Test Event #{System.unique_integer([:positive])}",
+      starts_at: ~U[2030-06-01 10:00:00Z],
+      ends_at: ~U[2030-06-01 18:00:00Z],
+      venue: "Main Stage"
+    }
+
+    {:ok, event} = Events.create_event(org, Enum.into(attrs, base))
+    event
+  end
+
+  defp discount_rule_fixture(event, attrs \\ %{}) do
+    base = %{
+      name: "Regra Teste #{System.unique_integer([:positive])}",
+      condition_type: "min_quantity",
+      min_quantity: 2,
+      value_type: "percentage",
+      value: 1000,
+      active: true
+    }
+
+    {:ok, rule} = Discounts.create_discount_rule(event, Enum.into(attrs, base))
+    rule
+  end
+
+  # ---------------------------------------------------------------------------
+  # Index — listing discount rules
+  # ---------------------------------------------------------------------------
+
+  describe "Index - listing discount rules" do
+    setup :register_and_log_in_user
+
+    test "renders the discounts page for an event", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org, %{name: "Rock Festival"})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "Descontos Automáticos"
+      assert html =~ "Rock Festival"
+    end
+
+    test "shows empty state when no discount rules exist", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "Nenhuma regra de desconto cadastrada"
+    end
+
+    test "lists discount rules for the event", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Desconto de Grupo"})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ rule.name
+    end
+
+    test "does not show rules from other events", %{conn: conn} do
+      org = org_fixture()
+      event1 = event_fixture(org)
+      event2 = event_fixture(org)
+      _rule = discount_rule_fixture(event1, %{name: "Regra do Evento 1 Exclusiva"})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event2}/discounts")
+
+      refute html =~ "Regra do Evento 1 Exclusiva"
+    end
+
+    test "shows active badge for an active rule", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      discount_rule_fixture(event, %{active: true})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "Ativo"
+    end
+
+    test "shows inactive badge for an inactive rule", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      discount_rule_fixture(event, %{active: false})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "Inativo"
+    end
+
+    test "shows percentage condition label", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      discount_rule_fixture(event, %{condition_type: "min_quantity", min_quantity: 3})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "3"
+    end
+
+    test "shows fixed discount effect value", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      discount_rule_fixture(event, %{
+        name: "Desconto Fixo",
+        value_type: "fixed",
+        value: 1000
+      })
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "10,00"
+    end
+
+    test "shows percentage discount effect value", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      discount_rule_fixture(event, %{
+        name: "Desconto Percentual",
+        value_type: "percentage",
+        value: 500
+      })
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "5,00%"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # New — create discount rule form
+  # ---------------------------------------------------------------------------
+
+  describe "New - create discount rule" do
+    setup :register_and_log_in_user
+
+    test "renders the new form", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      assert html =~ "Nova Regra de Desconto"
+      assert html =~ "Nome"
+      assert html =~ "Tipo de Condição"
+    end
+
+    test "creates a min_quantity percentage discount rule", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "Desconto Grupo 3+",
+            condition_type: "min_quantity",
+            min_quantity: 3,
+            value_type: "percentage",
+            value: 1000,
+            active: true
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Desconto Grupo 3+"
+    end
+
+    test "creates a fixed discount rule", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "Desconto R$10",
+            condition_type: "min_quantity",
+            min_quantity: 1,
+            value_type: "fixed",
+            value: 1000,
+            active: true
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Desconto R$10"
+    end
+
+    test "shows validation error for negative value", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "Inválido",
+            condition_type: "min_quantity",
+            value_type: "fixed",
+            value: -100
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "must be greater than or equal to"
+    end
+
+    test "shows validation error for percentage above 10000", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "Percentual Inválido",
+            condition_type: "min_quantity",
+            value_type: "percentage",
+            value: 10_001
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "não pode exceder 100%"
+    end
+
+    test "shows validation error when name is too short", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "X",
+            condition_type: "min_quantity",
+            value_type: "fixed",
+            value: 100
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "should be at least"
+    end
+
+    test "validate event keeps form open and shows changes", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "Teste Validação",
+            condition_type: "min_quantity",
+            value_type: "percentage",
+            value: 500
+          }
+        })
+        |> render_change()
+
+      assert html =~ "Teste Validação"
+    end
+
+    test "close_modal navigates back to index", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/new")
+
+      view
+      |> element("button[phx-click='close_modal']", "Cancelar")
+      |> render_click()
+
+      assert_patch(view, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Edit — update discount rule
+  # ---------------------------------------------------------------------------
+
+  describe "Edit - update discount rule" do
+    setup :register_and_log_in_user
+
+    test "renders the edit form with existing values", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Regra Original", value: 1500})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/#{rule.id}/edit")
+
+      assert html =~ "Editar Regra de Desconto"
+      assert html =~ "Regra Original"
+    end
+
+    test "editing a rule updates it", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Antes da Edição", value: 500})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/#{rule.id}/edit")
+
+      html =
+        view
+        |> form("#discount-rule-form", %{
+          discount_rule: %{
+            name: "Depois da Edição",
+            condition_type: "min_quantity",
+            min_quantity: 2,
+            value_type: "percentage",
+            value: 2000
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Depois da Edição"
+      refute html =~ "Antes da Edição"
+    end
+
+    test "editing a rule shows flash success message", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Regra Para Editar"})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts/#{rule.id}/edit")
+
+      view
+      |> form("#discount-rule-form", %{
+        discount_rule: %{
+          name: "Regra Editada",
+          condition_type: "min_quantity",
+          min_quantity: 1,
+          value_type: "fixed",
+          value: 500
+        }
+      })
+      |> render_submit()
+
+      assert_patch(view, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      html = render(view)
+      assert html =~ "atualizada com sucesso"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Delete — remove discount rule
+  # ---------------------------------------------------------------------------
+
+  describe "Delete - remove discount rule" do
+    setup :register_and_log_in_user
+
+    test "deleting a rule removes it from the list", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Regra Para Excluir"})
+
+      {:ok, view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ rule.name
+
+      view
+      |> element("[phx-click='delete'][phx-value-id='#{rule.id}']")
+      |> render_click()
+
+      html = render(view)
+      refute html =~ rule.name
+    end
+
+    test "shows flash success after deletion", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{name: "Excluível"})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      view
+      |> element("[phx-click='delete'][phx-value-id='#{rule.id}']")
+      |> render_click()
+
+      assert render(view) =~ "removida com sucesso"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Toggle active
+  # ---------------------------------------------------------------------------
+
+  describe "Toggle active" do
+    setup :register_and_log_in_user
+
+    test "toggling active on an active rule makes it inactive", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{active: true})
+
+      {:ok, view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "Ativo"
+
+      view
+      |> element("[phx-click='toggle_active'][phx-value-id='#{rule.id}']")
+      |> render_click()
+
+      assert render(view) =~ "Inativo"
+    end
+
+    test "toggling active on an inactive rule makes it active", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      rule = discount_rule_fixture(event, %{active: false})
+
+      {:ok, view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/events/#{event}/discounts")
+
+      assert html =~ "Inativo"
+
+      view
+      |> element("[phx-click='toggle_active'][phx-value-id='#{rule.id}']")
+      |> render_click()
+
+      assert render(view) =~ "Ativo"
+    end
+  end
+end

--- a/pretex/test/pretex_web/live/admin/gift_card_live_test.exs
+++ b/pretex/test/pretex_web/live/admin/gift_card_live_test.exs
@@ -1,0 +1,476 @@
+defmodule PretexWeb.Admin.GiftCardLiveTest do
+  use PretexWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Pretex.Organizations
+  alias Pretex.GiftCards
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp org_fixture(attrs \\ %{}) do
+    {:ok, org} =
+      attrs
+      |> Enum.into(%{name: "Test Org", slug: "test-org-#{System.unique_integer([:positive])}"})
+      |> Organizations.create_organization()
+
+    org
+  end
+
+  defp gift_card_fixture(org, attrs \\ %{}) do
+    base = %{
+      code: "GC-TEST#{System.unique_integer([:positive])}",
+      balance_cents: 5000,
+      active: true
+    }
+
+    {:ok, gc} = GiftCards.create_gift_card(org, Enum.into(attrs, base))
+    gc
+  end
+
+  # ---------------------------------------------------------------------------
+  # Index — listing gift cards
+  # ---------------------------------------------------------------------------
+
+  describe "Index - listing gift cards" do
+    setup :register_and_log_in_user
+
+    test "renders the gift cards page for an organization", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ "Vale-Presentes"
+      assert html =~ org.name
+    end
+
+    test "shows empty state when no gift cards exist", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ "Nenhum vale-presente cadastrado"
+    end
+
+    test "lists gift cards for the organization", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-LISTED01"})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ gc.code
+    end
+
+    test "shows gift card balance", %{conn: conn} do
+      org = org_fixture()
+      _gc = gift_card_fixture(org, %{code: "GC-BALANCE1", balance_cents: 10_000})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ "R$ 100,00"
+    end
+
+    test "shows active badge for active gift card", %{conn: conn} do
+      org = org_fixture()
+      _gc = gift_card_fixture(org, %{code: "GC-ACTIVE01", active: true})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ "Ativo"
+    end
+
+    test "shows inactive badge for inactive gift card", %{conn: conn} do
+      org = org_fixture()
+      _gc = gift_card_fixture(org, %{code: "GC-INACT01", active: false})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ "Inativo"
+    end
+
+    test "shows link back to organization", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ "Voltar à Organização"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # New gift card form
+  # ---------------------------------------------------------------------------
+
+  describe "New gift card form" do
+    setup :register_and_log_in_user
+
+    test "renders the new gift card modal", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      assert html =~ "Novo Vale-Presente"
+      assert html =~ "Código"
+      assert html =~ "Saldo"
+    end
+
+    test "auto-generates a code when opening the new form", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      assert html =~ "GC-"
+    end
+
+    test "creates a gift card with valid attrs", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      html =
+        view
+        |> form("#gift-card-form", %{
+          "gift_card" => %{
+            "code" => "GC-NEWCARD1",
+            "balance_cents" => "5000",
+            "initial_balance_cents" => "5000",
+            "active" => "true"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Vale-presente criado com sucesso"
+
+      gc = GiftCards.get_gift_card_by_code("GC-NEWCARD1")
+      assert {:ok, _} = gc
+    end
+
+    test "shows validation errors for missing code", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      html =
+        view
+        |> form("#gift-card-form", %{
+          "gift_card" => %{
+            "code" => "",
+            "balance_cents" => "5000"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "can&#39;t be blank" or html =~ "can't be blank"
+    end
+
+    test "shows validation errors for negative balance", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      html =
+        view
+        |> form("#gift-card-form", %{
+          "gift_card" => %{
+            "code" => "GC-NEGBAL01",
+            "balance_cents" => "-100"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "must be greater than or equal to"
+    end
+
+    test "generate_code button populates the code field", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      html = render_click(view, "generate_code")
+
+      assert html =~ "GC-"
+    end
+
+    test "shows duplicate code error", %{conn: conn} do
+      org = org_fixture()
+      _existing = gift_card_fixture(org, %{code: "GC-DUPTEST1"})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      html =
+        view
+        |> form("#gift-card-form", %{
+          "gift_card" => %{
+            "code" => "GC-DUPTEST1",
+            "balance_cents" => "1000"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "has already been taken"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Edit gift card
+  # ---------------------------------------------------------------------------
+
+  describe "Edit gift card" do
+    setup :register_and_log_in_user
+
+    test "renders the edit gift card modal", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-EDIT01"})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/edit")
+
+      assert html =~ "Editar Vale-Presente"
+      assert html =~ gc.code
+    end
+
+    test "updates a gift card with valid attrs", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-EDIT02", note: "original"})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/edit")
+
+      html =
+        view
+        |> form("#gift-card-form", %{
+          "gift_card" => %{
+            "code" => gc.code,
+            "balance_cents" => "8000",
+            "note" => "updated note"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Vale-presente atualizado com sucesso"
+
+      updated = GiftCards.get_gift_card!(gc.id)
+      assert updated.balance_cents == 8000
+      assert updated.note == "updated note"
+    end
+
+    test "validates on change", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-VALCH01"})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/edit")
+
+      html =
+        view
+        |> form("#gift-card-form", %{
+          "gift_card" => %{
+            "code" => gc.code,
+            "balance_cents" => "-1"
+          }
+        })
+        |> render_change()
+
+      assert html =~ "must be greater than or equal to"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Delete gift card
+  # ---------------------------------------------------------------------------
+
+  describe "Delete gift card" do
+    setup :register_and_log_in_user
+
+    test "deletes a gift card", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-DELETE01"})
+
+      {:ok, view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert html =~ gc.code
+
+      html =
+        view
+        |> element("[phx-click='delete'][phx-value-id='#{gc.id}']")
+        |> render_click()
+
+      assert html =~ "Vale-presente removido com sucesso"
+      refute html =~ gc.code
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Toggle active
+  # ---------------------------------------------------------------------------
+
+  describe "Toggle active" do
+    setup :register_and_log_in_user
+
+    test "toggles a gift card from active to inactive", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOGGLE01", active: true})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      html =
+        view
+        |> element("[phx-click='toggle_active'][phx-value-id='#{gc.id}']")
+        |> render_click()
+
+      assert html =~ "Inativo"
+
+      updated = GiftCards.get_gift_card!(gc.id)
+      assert updated.active == false
+    end
+
+    test "toggles a gift card from inactive to active", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOGGLE02", active: false})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      html =
+        view
+        |> element("[phx-click='toggle_active'][phx-value-id='#{gc.id}']")
+        |> render_click()
+
+      assert html =~ "Ativo"
+
+      updated = GiftCards.get_gift_card!(gc.id)
+      assert updated.active == true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Top-up
+  # ---------------------------------------------------------------------------
+
+  describe "Top-up gift card" do
+    setup :register_and_log_in_user
+
+    test "renders the top-up modal", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOPUP01"})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/top-up")
+
+      assert html =~ "Recarregar Vale-Presente"
+      assert html =~ gc.code
+    end
+
+    test "shows current balance in the top-up modal", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOPUP02", balance_cents: 5000})
+
+      {:ok, _view, html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/top-up")
+
+      assert html =~ "R$ 50,00"
+    end
+
+    test "adds balance successfully", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOPUP03", balance_cents: 5000})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/top-up")
+
+      html =
+        view
+        |> form("#top-up-form", %{"top_up" => %{"amount_cents" => "2000"}})
+        |> render_submit()
+
+      assert html =~ "Vale-presente recarregado com sucesso"
+
+      updated = GiftCards.get_gift_card!(gc.id)
+      assert updated.balance_cents == 7000
+    end
+
+    test "shows error for zero amount", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOPUP04", balance_cents: 5000})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/top-up")
+
+      html =
+        view
+        |> form("#top-up-form", %{"top_up" => %{"amount_cents" => "0"}})
+        |> render_submit()
+
+      assert html =~ "valor válido"
+    end
+
+    test "shows error for invalid (non-numeric) amount", %{conn: conn} do
+      org = org_fixture()
+      gc = gift_card_fixture(org, %{code: "GC-TOPUP05", balance_cents: 5000})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/#{gc.id}/top-up")
+
+      html =
+        view
+        |> form("#top-up-form", %{"top_up" => %{"amount_cents" => "abc"}})
+        |> render_submit()
+
+      assert html =~ "valor válido"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Close modal
+  # ---------------------------------------------------------------------------
+
+  describe "Close modal" do
+    setup :register_and_log_in_user
+
+    test "close_modal event navigates back to index", %{conn: conn} do
+      org = org_fixture()
+
+      {:ok, view, _html} =
+        live(conn, ~p"/admin/organizations/#{org}/gift-cards/new")
+
+      html = render_click(view, "close_modal")
+
+      # Should no longer show the modal content
+      refute html =~ "Criar Vale-Presente"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Authentication guard
+  # ---------------------------------------------------------------------------
+
+  describe "Authentication" do
+    test "redirects unauthenticated users", %{conn: conn} do
+      org = org_fixture()
+
+      assert {:error, redirect} =
+               live(conn, ~p"/admin/organizations/#{org}/gift-cards")
+
+      assert {:redirect, %{to: path}} = redirect
+      assert path =~ "/staff/log-in"
+    end
+  end
+end

--- a/pretex/test/pretex_web/live/checkout_gift_card_test.exs
+++ b/pretex/test/pretex_web/live/checkout_gift_card_test.exs
@@ -1,0 +1,573 @@
+defmodule PretexWeb.CheckoutGiftCardTest do
+  use PretexWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Pretex.Events
+  alias Pretex.Organizations
+  alias Pretex.Orders
+  alias Pretex.GiftCards
+  alias Pretex.Repo
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp org_fixture do
+    {:ok, org} =
+      %{name: "Test Org", slug: "test-org-#{System.unique_integer([:positive])}"}
+      |> Organizations.create_organization()
+
+    org
+  end
+
+  defp event_fixture(org) do
+    {:ok, event} =
+      Events.create_event(org, %{
+        name: "Test Event #{System.unique_integer([:positive])}",
+        starts_at: ~U[2030-06-01 10:00:00Z],
+        ends_at: ~U[2030-06-01 18:00:00Z],
+        venue: "Main Stage",
+        slug: "test-event-#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, _item} =
+      Pretex.Catalog.create_item(event, %{
+        name: "Ingresso Geral",
+        price_cents: 5000
+      })
+
+    {:ok, published} = Events.publish_event(event)
+    published
+  end
+
+  defp item_fixture(event, price_cents \\ 5000) do
+    {:ok, item} =
+      Pretex.Catalog.create_item(event, %{
+        name: "Ingresso Específico #{System.unique_integer([:positive])}",
+        price_cents: price_cents
+      })
+
+    item
+  end
+
+  defp cart_fixture(event, item) do
+    {:ok, cart} = Orders.create_cart(event)
+    {:ok, _} = Orders.add_to_cart(cart, item, quantity: 1)
+    Orders.get_cart_by_token(cart.session_token)
+  end
+
+  defp gift_card_fixture(org, attrs \\ %{}) do
+    base = %{
+      code: "GC-TEST#{System.unique_integer([:positive])}",
+      balance_cents: 5000,
+      active: true
+    }
+
+    {:ok, gc} = GiftCards.create_gift_card(org, Enum.into(attrs, base))
+    gc
+  end
+
+  defp navigate_to_summary(conn, event, cart) do
+    live(conn, ~p"/events/#{event.slug}/checkout/summary?cart_token=#{cart.session_token}")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Summary step — gift card input UI
+  # ---------------------------------------------------------------------------
+
+  describe "Checkout summary — gift card UI" do
+    test "shows gift card code input form on summary page", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+
+      {:ok, _view, html} = navigate_to_summary(conn, event, cart)
+
+      assert html =~ "Código do vale-presente"
+      assert html =~ "apply_gift_card"
+    end
+
+    test "shows 'Aplicar' button for gift card input", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+
+      {:ok, _view, html} = navigate_to_summary(conn, event, cart)
+
+      assert html =~ "Aplicar"
+    end
+
+    test "gift card input is hidden when a gift card is applied", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      refute html =~ "Código do vale-presente"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Applying gift cards
+  # ---------------------------------------------------------------------------
+
+  describe "apply_gift_card event" do
+    test "applying a valid gift card shows the deduction in the summary", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ gc.code
+      assert html =~ "R$ 20,00"
+    end
+
+    test "applying a gift card shows badge with code", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{code: "GC-BADGE01", balance_cents: 1000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "GC-BADGE01"
+      assert html =~ "Remover"
+    end
+
+    test "applying a gift card reduces the displayed grand total", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      html = render(view)
+
+      # Total should be 5000 - 2000 = 3000 = R$ 30,00
+      assert html =~ "R$ 30,00"
+    end
+
+    test "applying a gift card case-insensitively works", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{code: "GC-CITEST1", balance_cents: 1000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => "gc-citest1"})
+        |> render_submit()
+
+      assert html =~ "GC-CITEST1"
+    end
+
+    test "applying a gift card when card balance exceeds order total shows 100% deduction",
+         %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 1000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 50_000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      html = render(view)
+
+      # Grand total should be "Grátis" (format_price(0) returns "Grátis")
+      assert html =~ "Grátis"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gift card error messages
+  # ---------------------------------------------------------------------------
+
+  describe "gift card error messages" do
+    test "shows error for a non-existent gift card code", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => "GC-DOESNOTEXIST"})
+        |> render_submit()
+
+      assert html =~ "Vale-presente não encontrado"
+    end
+
+    test "shows error for a gift card from wrong organization", %{conn: conn} do
+      org1 = org_fixture()
+      org2 = org_fixture()
+      event = event_fixture(org2)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org1, %{balance_cents: 1000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "não é válido para este evento"
+    end
+
+    test "shows error for an expired gift card", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      gc = gift_card_fixture(org, %{balance_cents: 1000, expires_at: past})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "expirado"
+    end
+
+    test "shows error for an empty (zero balance) gift card", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 0})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "sem saldo"
+    end
+
+    test "shows error for an inactive gift card", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 1000, active: false})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "inativo"
+    end
+
+    test "shows error for empty code submission", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event)
+      cart = cart_fixture(event, item)
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => ""})
+        |> render_submit()
+
+      assert html =~ "Por favor insira um código"
+    end
+
+    test "error disappears when a valid card is applied after an error", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 1000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      # First apply invalid code
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => "GC-WRONG"})
+      |> render_submit()
+
+      # Then apply valid code
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      refute html =~ "Vale-presente não encontrado"
+      assert html =~ gc.code
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Removing gift cards
+  # ---------------------------------------------------------------------------
+
+  describe "remove_gift_card event" do
+    test "removing a gift card clears the deduction", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      # Apply
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      # Remove
+      html = render_click(view, "remove_gift_card")
+
+      # Gift card badge should be gone
+      refute html =~ gc.code
+      # Input form should be back
+      assert html =~ "Código do vale-presente"
+    end
+
+    test "removing a gift card restores the original grand total", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      # Apply
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      # Remove
+      html = render_click(view, "remove_gift_card")
+
+      # Total should be back to R$ 50,00
+      assert html =~ "R$ 50,00"
+    end
+
+    test "removing a gift card clears any gift card error", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      # Apply a valid gift card
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      # Remove it
+      html = render_click(view, "remove_gift_card")
+
+      refute html =~ "Vale-presente não encontrado"
+      refute html =~ "expirado"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Placing an order with a gift card
+  # ---------------------------------------------------------------------------
+
+  describe "place_order with gift card" do
+    test "placing an order with a valid gift card deducts from order total", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{code: "GC-PLACE01", balance_cents: 2000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      # Fill in attendee info step first
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      # Navigate to info step, fill in details
+      {:ok, view, _} =
+        live(conn, ~p"/events/#{event.slug}/checkout?cart_token=#{cart.session_token}")
+
+      view
+      |> form("form[phx-submit=submit_info]", %{
+        "checkout" => %{"name" => "João Silva", "email" => "joao@example.com"}
+      })
+      |> render_submit()
+
+      # Back to summary step with gift card
+      {:ok, view, _} = navigate_to_summary(conn, event, cart)
+
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      # The gift card code should be set and visible in summary
+      html = render(view)
+      assert html =~ gc.code
+    end
+
+    test "gift card deduction appears in order summary before placing order", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 1500})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "R$ 15,00"
+    end
+
+    test "placed order has a gift card redemption record", %{conn: _conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-ORDREC1", balance_cents: 2000})
+
+      item = item_fixture(event, 5000)
+      {:ok, cart} = Orders.create_cart(event)
+      {:ok, _} = Orders.add_to_cart(cart, item, quantity: 1)
+      cart = Orders.get_cart_by_token(cart.session_token)
+
+      {:ok, order} =
+        Orders.create_order_from_cart(cart, %{
+          name: "João Silva",
+          email: "joao@example.com",
+          payment_method: "pix",
+          gift_card_code: gc.code
+        })
+
+      redemption = GiftCards.get_debit_redemption_for_order(order.id)
+
+      assert redemption != nil
+      assert redemption.amount_cents == 2000
+      assert order.total_cents == 3000
+    end
+
+    test "placed order with gift card reduces card balance", %{conn: _conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      gc = gift_card_fixture(org, %{code: "GC-BALRED1", balance_cents: 3000})
+
+      item = item_fixture(event, 5000)
+      {:ok, cart} = Orders.create_cart(event)
+      {:ok, _} = Orders.add_to_cart(cart, item, quantity: 1)
+      cart = Orders.get_cart_by_token(cart.session_token)
+
+      {:ok, _order} =
+        Orders.create_order_from_cart(cart, %{
+          name: "João Silva",
+          email: "joao@example.com",
+          payment_method: "pix",
+          gift_card_code: gc.code
+        })
+
+      updated_gc = Repo.get!(Pretex.GiftCards.GiftCard, gc.id)
+      assert updated_gc.balance_cents == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Subtotal visibility with gift card
+  # ---------------------------------------------------------------------------
+
+  describe "subtotal row with gift card" do
+    test "subtotal row appears when gift card is applied", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 1000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      html =
+        view
+        |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+        |> render_submit()
+
+      assert html =~ "Subtotal"
+    end
+
+    test "subtotal row disappears when gift card is removed and no fees/discounts", %{conn: conn} do
+      org = org_fixture()
+      event = event_fixture(org)
+      item = item_fixture(event, 5000)
+      cart = cart_fixture(event, item)
+      gc = gift_card_fixture(org, %{balance_cents: 1000})
+
+      {:ok, view, _html} = navigate_to_summary(conn, event, cart)
+
+      # Apply
+      view
+      |> form("form[phx-submit=apply_gift_card]", %{"code" => gc.code})
+      |> render_submit()
+
+      # Remove
+      html = render_click(view, "remove_gift_card")
+
+      # Subtotal should not appear when there are no fees, discounts, or gift cards
+      refute html =~ "Subtotal"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements **Story 016: Discounts** — organizers define automatic discount rules based on quantity thresholds or item combinations. At checkout the best matching rule is applied without any code needed.

Closes #18

## Acceptance Criteria Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC1 | Create discount rules with conditions (min quantity, item combo) and effects (fixed cents, percentage) | ✅ |
| AC2 | Scope discounts to specific items via join table | ✅ |
| AC3 | Automatic application at checkout — shown in real-time pricing summary | ✅ |
| AC4 | Best-discount wins — highest discount_cents among all matching rules is selected | ✅ |

## Changes

### Database
- Migration `20260319270001`: `discount_rules` table — name, condition_type, min_quantity, value_type, value (basis points or cents), active, description
- Migration `20260319270002`: `discount_rule_items` join table — scopes rules to specific items/variations
- Migration `20260319270003`: `order_discounts` table — immutable snapshot per order with `nilify_all` on rule deletion

### Schemas
- `Pretex.Discounts.DiscountRule` — full validation (non-negative, percentage ≤ 100%, min_quantity ≥ 1)
- `Pretex.Discounts.DiscountRuleItem` — item/variation scoping join table
- `Pretex.Discounts.OrderDiscount` — records the applied discount with original rule reference
- `Pretex.Orders.Order` — updated with `has_many :discounts`

### Context (`Pretex.Discounts`)
- Full CRUD + `change_discount_rule/2`
- `evaluate_cart/2` — evaluates ALL active rules against cart items; returns matching entries sorted by `discount_cents` descending
- `best_discount/2` — picks the highest-discount entry (AC4)
- `compute_discount_for_cart/2` — integer preview (0 if no match) for checkout display
- `apply_best_discount/2` — raw `Repo` operations (participates in caller's outer transaction); inserts `OrderDiscount`, updates `order.total_cents`, capped at zero

### Pricing Pipeline Order (inside `create_order_from_cart` transaction)
1. Items inserted + quota incremented
2. **Discount applied** (reduces subtotal first)
3. Fees computed on discounted total
4. Voucher applied on discounted+fee total

This gives attendees the most favorable price and follows the spec's pricing evaluation order.

### Condition Evaluation
| Condition | Scoped Items | Behaviour |
|-----------|-------------|-----------|
| `min_quantity` | none | count ALL cart item quantities |
| `min_quantity` | some items | count only quantities for those items |
| `item_combo` | required | all scoped item_ids must be present in cart |

### Discount Calculation
| Value Type | Formula |
|------------|---------|
| `fixed` | `min(rule.value_cents, applicable_subtotal)` |
| `percentage` | `round(applicable_subtotal * rule.value / 10000)` |

### Checkout LiveView (AC3)
- `discount_preview` and `applied_discount_rule_name` assigns computed on cart load
- Automatic discount row shown between subtotal and fee rows (green, with rule name)
- Grand total: `cart_total + fee_total - discount_preview - voucher_discount`

### Admin UI
- `DiscountLive.Index` — stream-based list, create/edit modal, toggle active, delete
- 3 new routes under `/organizations/:org_id/events/:event_id/discounts`
- "Descontos Automáticos" card on event show page

### Tests
- 72 new tests: CRUD, evaluation logic, integration, LiveView
- **1298 total tests, 0 failures, 0 warnings**

## Notes
- This PR targets `feat/story-015-vouchers` (stacked on Story 015).
- Item scoping UI (selecting which items a rule applies to) is a future enhancement — the schema and join table are ready.
- Discount stacking disabled by design: only the single best discount is applied per order.