### PR TITLE
feat(memberships): admin UI, customer memberships page, and item_access enforcement (Story 18)

### DIFF
--- a/pretex/lib/pretex/memberships.ex
+++ b/pretex/lib/pretex/memberships.ex
@@ -45,6 +45,14 @@ defmodule Pretex.Memberships do
     Repo.delete(mt)
   end
 
+  def change_membership_type(%MembershipType{} = mt, attrs \\ %{}) do
+    MembershipType.changeset(mt, attrs)
+  end
+
+  def change_benefit(%MembershipBenefit{} = b, attrs \\ %{}) do
+    MembershipBenefit.changeset(b, attrs)
+  end
+
   # ---------------------------------------------------------------------------
   # MembershipBenefit CRUD
   # ---------------------------------------------------------------------------
@@ -104,6 +112,48 @@ defmodule Pretex.Memberships do
     |> where([m], m.customer_id == ^customer.id and m.status == "active")
     |> preload(membership_type: :benefits)
     |> Repo.all()
+  end
+
+  @doc """
+  Returns true if any membership benefit with item_access targets the given item_id.
+  Used to determine whether an item requires membership to purchase.
+  """
+  def item_requires_membership?(item_id) do
+    MembershipBenefit
+    |> where([b], b.benefit_type == "item_access" and b.value == ^item_id)
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Returns a MapSet of item IDs (from the given list) that require membership to access.
+  Avoids N+1 queries when rendering a list of items.
+  """
+  def restricted_item_ids(item_ids) when is_list(item_ids) do
+    MembershipBenefit
+    |> where([b], b.benefit_type == "item_access" and b.value in ^item_ids)
+    |> select([b], b.value)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
+  Returns true if the customer has an active (non-expired) membership within the org
+  that grants item_access to the given item_id.
+  """
+  def customer_has_item_access?(customer_id, org_id, item_id) do
+    now = DateTime.utc_now(:second)
+
+    Membership
+    |> where([m],
+      m.customer_id == ^customer_id and
+        m.organization_id == ^org_id and
+        m.status == "active" and
+        m.expires_at > ^now
+    )
+    |> join(:inner, [m], mt in assoc(m, :membership_type))
+    |> join(:inner, [m, mt], b in assoc(mt, :benefits))
+    |> where([m, mt, b], b.benefit_type == "item_access" and b.value == ^item_id)
+    |> Repo.exists?()
   end
 
   def active_memberships_for_checkout(customer, %{id: org_id}) do

--- a/pretex/lib/pretex_web/components/dashboard.ex
+++ b/pretex/lib/pretex_web/components/dashboard.ex
@@ -61,6 +61,11 @@ defmodule PretexWeb.Components.Dashboard do
         label: "Pagamentos",
         path: "/admin/organizations/#{org_id}/payments"
       },
+      %{
+        icon: "hero-identification",
+        label: "Associações",
+        path: "/admin/organizations/#{org_id}/memberships"
+      },
       %{icon: "hero-chart-bar", label: "Relatórios", path: "#", disabled: true},
       %{icon: "hero-cog-6-tooth", label: "Configurações", path: "#", disabled: true}
     ]
@@ -346,10 +351,20 @@ defmodule PretexWeb.Components.Dashboard do
               href="/account/orders"
               class={[
                 "hover:text-primary transition-colors",
-                String.starts_with?(@current_path, "/account") && "text-primary font-medium"
+                @current_path == "/account/orders" && "text-primary font-medium"
               ]}
             >
-              Minha Conta
+              Meus Pedidos
+            </a>
+            <a
+              :if={@current_scope && @current_scope.customer}
+              href="/account/memberships"
+              class={[
+                "hover:text-primary transition-colors",
+                @current_path == "/account/memberships" && "text-primary font-medium"
+              ]}
+            >
+              Associações
             </a>
           </div>
 

--- a/pretex/lib/pretex_web/live/admin/membership_live/index.ex
+++ b/pretex/lib/pretex_web/live/admin/membership_live/index.ex
@@ -1,0 +1,263 @@
+defmodule PretexWeb.Admin.MembershipLive.Index do
+  use PretexWeb, :live_view
+
+  alias Pretex.Customers
+  alias Pretex.Memberships
+  alias Pretex.Memberships.MembershipBenefit
+  alias Pretex.Memberships.MembershipType
+  alias Pretex.Organizations
+
+  @impl true
+  def mount(%{"org_id" => org_id}, _session, socket) do
+    org = Organizations.get_organization!(org_id)
+    membership_types = Memberships.list_membership_types(org)
+
+    socket =
+      socket
+      |> assign(:org, org)
+      |> assign(:page_title, "Associações — #{org.name}")
+      |> assign(:membership_type, nil)
+      |> assign(:form, nil)
+      |> assign(:grant_form, nil)
+      |> assign(:benefit_form, nil)
+      |> stream(:membership_types, membership_types)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Associações — #{socket.assigns.org.name}")
+    |> assign(:membership_type, nil)
+    |> assign(:form, nil)
+    |> assign(:grant_form, nil)
+    |> assign(:benefit_form, nil)
+  end
+
+  defp apply_action(socket, :new, _params) do
+    mt = %MembershipType{}
+
+    socket
+    |> assign(:page_title, "Nova Associação")
+    |> assign(:membership_type, mt)
+    |> assign(:form, to_form(Memberships.change_membership_type(mt)))
+    |> assign(:grant_form, nil)
+    |> assign(:benefit_form, nil)
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    mt = Memberships.get_membership_type!(id)
+
+    socket
+    |> assign(:page_title, "Editar Associação")
+    |> assign(:membership_type, mt)
+    |> assign(:form, to_form(Memberships.change_membership_type(mt)))
+    |> assign(:grant_form, nil)
+    |> assign(:benefit_form, to_form(Memberships.change_benefit(%MembershipBenefit{})))
+  end
+
+  defp apply_action(socket, :grant, %{"id" => id}) do
+    mt = Memberships.get_membership_type!(id)
+
+    socket
+    |> assign(:page_title, "Conceder Associação")
+    |> assign(:membership_type, mt)
+    |> assign(:form, nil)
+    |> assign(:grant_form, to_form(%{"email" => ""}, as: :grant))
+    |> assign(:benefit_form, nil)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def handle_event("validate", %{"membership_type" => params}, socket) do
+    changeset =
+      socket.assigns.membership_type
+      |> Memberships.change_membership_type(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form, to_form(changeset))}
+  end
+
+  def handle_event("save", %{"membership_type" => params}, socket) do
+    case socket.assigns.live_action do
+      :new -> do_create(socket, params)
+      :edit -> do_update(socket, params)
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    mt = Memberships.get_membership_type!(id)
+
+    case Memberships.delete_membership_type(mt) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Associação removida com sucesso.")
+         |> stream_delete(:membership_types, mt)}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Não foi possível remover a associação. Pode haver membros ativos vinculados a ela."
+         )}
+    end
+  end
+
+  def handle_event("toggle_active", %{"id" => id}, socket) do
+    mt = Memberships.get_membership_type!(id)
+
+    case Memberships.update_membership_type(mt, %{active: !mt.active}) do
+      {:ok, updated} ->
+        {:noreply, stream_insert(socket, :membership_types, updated)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Não foi possível alterar o status da associação.")}
+    end
+  end
+
+  def handle_event("validate_benefit", %{"membership_benefit" => params}, socket) do
+    changeset =
+      %MembershipBenefit{}
+      |> Memberships.change_benefit(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :benefit_form, to_form(changeset))}
+  end
+
+  def handle_event("add_benefit", %{"membership_benefit" => params}, socket) do
+    mt = socket.assigns.membership_type
+
+    case Memberships.create_benefit(mt, params) do
+      {:ok, _benefit} ->
+        updated_mt = Memberships.get_membership_type!(mt.id)
+
+        {:noreply,
+         socket
+         |> assign(:membership_type, updated_mt)
+         |> assign(:benefit_form, to_form(Memberships.change_benefit(%MembershipBenefit{})))
+         |> stream_insert(:membership_types, updated_mt)}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :benefit_form, to_form(changeset))}
+    end
+  end
+
+  def handle_event("delete_benefit", %{"id" => benefit_id}, socket) do
+    mt = socket.assigns.membership_type
+    benefit = Enum.find(mt.benefits, &(to_string(&1.id) == benefit_id))
+
+    if benefit do
+      case Memberships.delete_benefit(benefit) do
+        {:ok, _} ->
+          updated_mt = Memberships.get_membership_type!(mt.id)
+
+          {:noreply,
+           socket
+           |> assign(:membership_type, updated_mt)
+           |> stream_insert(:membership_types, updated_mt)}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, "Não foi possível remover o benefício.")}
+      end
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("grant", %{"grant" => %{"email" => email}}, socket) do
+    mt = socket.assigns.membership_type
+    org = socket.assigns.org
+
+    case Customers.get_customer_by_email(email) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign(:grant_form, to_form(%{"email" => email}, as: :grant))
+         |> put_flash(:error, "Nenhum cliente encontrado com o e-mail #{email}.")}
+
+      customer ->
+        case Memberships.grant_membership(mt, customer, org) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Associação \"#{mt.name}\" concedida para #{email}.")
+             |> push_patch(to: ~p"/admin/organizations/#{org}/memberships")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Não foi possível conceder a associação.")}
+        end
+    end
+  end
+
+  def handle_event("close_modal", _params, socket) do
+    org = socket.assigns.org
+    {:noreply, push_patch(socket, to: ~p"/admin/organizations/#{org}/memberships")}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp do_create(socket, params) do
+    org = socket.assigns.org
+
+    case Memberships.create_membership_type(org, params) do
+      {:ok, mt} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Associação criada com sucesso.")
+         |> stream_insert(:membership_types, mt)
+         |> push_patch(to: ~p"/admin/organizations/#{org}/memberships")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp do_update(socket, params) do
+    org = socket.assigns.org
+    mt = socket.assigns.membership_type
+
+    case Memberships.update_membership_type(mt, params) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Associação atualizada com sucesso.")
+         |> stream_insert(:membership_types, updated)
+         |> push_patch(to: ~p"/admin/organizations/#{org}/memberships")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp benefit_label("percentage_discount"), do: "Desconto %"
+  defp benefit_label("fixed_discount"), do: "Desconto Fixo"
+  defp benefit_label("item_access"), do: "Acesso a Item"
+  defp benefit_label(type), do: type
+
+  defp benefit_value_display(%{benefit_type: "percentage_discount", value: v}) when is_integer(v) do
+    whole = div(v, 100)
+    frac = rem(v, 100)
+    "#{whole},#{String.pad_leading(to_string(frac), 2, "0")}%"
+  end
+
+  defp benefit_value_display(%{benefit_type: "fixed_discount", value: v}) when is_integer(v) do
+    whole = div(v, 100)
+    frac = rem(v, 100)
+    "R$ #{whole},#{String.pad_leading(to_string(frac), 2, "0")}"
+  end
+
+  defp benefit_value_display(%{benefit_type: "item_access"}), do: "Acesso exclusivo"
+  defp benefit_value_display(_), do: "—"
+end

--- a/pretex/lib/pretex_web/live/admin/membership_live/index.html.heex
+++ b/pretex/lib/pretex_web/live/admin/membership_live/index.html.heex
@@ -1,0 +1,359 @@
+<.dashboard_layout
+  current_path={~p"/admin/organizations/#{@org}/memberships"}
+  org={@org}
+  flash={@flash}
+>
+  <div class="mx-auto max-w-5xl px-4 py-8">
+    <%!-- Barra superior --%>
+    <div class="mb-6 flex items-center justify-between gap-4 flex-wrap">
+      <.link
+        navigate={~p"/admin/organizations/#{@org}"}
+        class="inline-flex items-center gap-1 text-sm text-base-content/60 hover:text-primary transition-colors"
+      >
+        <.icon name="hero-arrow-left" class="size-4" /> Voltar à Organização
+      </.link>
+
+      <.link
+        patch={~p"/admin/organizations/#{@org}/memberships/new"}
+        class="btn btn-primary btn-sm gap-1"
+      >
+        <.icon name="hero-plus" class="size-4" /> Nova Associação
+      </.link>
+    </div>
+
+    <%!-- Título da página --%>
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-base-content">Associações</h1>
+      <p class="text-sm text-base-content/60 mt-1">{@org.name}</p>
+    </div>
+
+    <%!-- Tabela de tipos de associação --%>
+    <div class="card bg-base-100 border border-base-200 shadow-sm overflow-hidden">
+      <div id="membership_types" phx-update="stream">
+        <%!-- Estado vazio --%>
+        <div
+          id="membership_types-empty-state"
+          class="hidden only:flex flex-col items-center justify-center py-20 text-center px-4"
+        >
+          <.icon name="hero-identification" class="size-12 text-base-content/20 mb-4" />
+          <p class="text-base font-semibold text-base-content/50">
+            Nenhuma associação cadastrada.
+          </p>
+          <p class="text-sm text-base-content/40 mt-1">
+            Crie tipos de associação para oferecer benefícios recorrentes aos seus membros.
+          </p>
+          <.link
+            patch={~p"/admin/organizations/#{@org}/memberships/new"}
+            class="btn btn-primary btn-sm mt-6 gap-1"
+          >
+            <.icon name="hero-plus" class="size-4" /> Nova Associação
+          </.link>
+        </div>
+
+        <div
+          :for={{dom_id, mt} <- @streams.membership_types}
+          id={dom_id}
+          class="flex flex-col sm:flex-row sm:items-center gap-3 px-5 py-4 border-b border-base-200 last:border-0 hover:bg-base-50 transition-colors"
+        >
+          <%!-- Nome e descrição --%>
+          <div class="flex-1 min-w-0">
+            <p class="font-semibold text-base-content">{mt.name}</p>
+            <p :if={mt.description} class="text-xs text-base-content/50 mt-0.5">{mt.description}</p>
+          </div>
+
+          <%!-- Validade --%>
+          <div class="shrink-0 text-right min-w-[110px]">
+            <p class="text-sm font-medium text-base-content">{mt.validity_days} dias</p>
+            <p class="text-xs text-base-content/40">validade</p>
+          </div>
+
+          <%!-- Benefícios --%>
+          <div class="shrink-0 text-right min-w-[90px]">
+            <p class="text-sm text-base-content/60">
+              {length(mt.benefits)}
+              {if length(mt.benefits) == 1, do: "benefício", else: "benefícios"}
+            </p>
+          </div>
+
+          <%!-- Status ativo --%>
+          <div class="shrink-0">
+            <span class={["badge badge-sm", mt.active && "badge-success", !mt.active && "badge-error"]}>
+              {if mt.active, do: "Ativo", else: "Inativo"}
+            </span>
+          </div>
+
+          <%!-- Ações --%>
+          <div class="flex items-center gap-2 shrink-0">
+            <button
+              phx-click="toggle_active"
+              phx-value-id={mt.id}
+              class="btn btn-ghost btn-xs"
+              title={if mt.active, do: "Desativar", else: "Ativar"}
+            >
+              {if mt.active, do: "Desativar", else: "Ativar"}
+            </button>
+
+            <.link
+              patch={~p"/admin/organizations/#{@org}/memberships/#{mt.id}/grant"}
+              class="btn btn-ghost btn-xs"
+            >
+              Conceder
+            </.link>
+
+            <.link
+              patch={~p"/admin/organizations/#{@org}/memberships/#{mt.id}/edit"}
+              class="btn btn-ghost btn-xs"
+            >
+              Editar
+            </.link>
+
+            <button
+              phx-click="delete"
+              phx-value-id={mt.id}
+              data-confirm="Excluir esta associação? Esta ação não pode ser desfeita."
+              class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-error-content"
+            >
+              Excluir
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Modal: Nova / Editar Associação --%>
+  <div :if={@live_action in [:new, :edit]}>
+    <div
+      id="membership-modal-backdrop"
+      class="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+      phx-click="close_modal"
+    >
+    </div>
+
+    <div
+      id="membership-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        class="w-full max-w-lg bg-base-100 rounded-2xl shadow-2xl border border-base-200 overflow-hidden max-h-[90vh] flex flex-col"
+        phx-click-away="close_modal"
+      >
+        <%!-- Cabeçalho do modal --%>
+        <div class="flex items-center justify-between px-6 py-4 border-b border-base-200 shrink-0">
+          <h2 class="text-lg font-bold text-base-content">
+            {if @live_action == :new, do: "Nova Associação", else: "Editar Associação"}
+          </h2>
+          <button
+            type="button"
+            phx-click="close_modal"
+            class="btn btn-ghost btn-sm btn-circle"
+            aria-label="Fechar"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
+
+        <%!-- Corpo do modal --%>
+        <div class="px-6 py-5 overflow-y-auto space-y-6">
+          <%!-- Formulário principal --%>
+          <.form
+            for={@form}
+            id="membership-type-form"
+            phx-change="validate"
+            phx-submit="save"
+            class="space-y-4"
+          >
+            <.input
+              field={@form[:name]}
+              type="text"
+              label="Nome"
+              placeholder="Ex: Membro Ouro, Apoiador Anual..."
+            />
+
+            <.input
+              field={@form[:description]}
+              type="text"
+              label="Descrição (opcional)"
+              placeholder="Descreva os benefícios desta associação..."
+            />
+
+            <.input
+              field={@form[:validity_days]}
+              type="number"
+              label="Validade (em dias)"
+              min="1"
+              placeholder="Ex: 365"
+            />
+
+            <.input
+              field={@form[:active]}
+              type="checkbox"
+              label="Ativo"
+            />
+
+            <div class="flex justify-end gap-3 pt-2">
+              <button type="button" phx-click="close_modal" class="btn btn-ghost btn-sm">
+                Cancelar
+              </button>
+              <.button type="submit" variant="primary" phx-disable-with="Salvando...">
+                {if @live_action == :new, do: "Criar Associação", else: "Salvar Alterações"}
+              </.button>
+            </div>
+          </.form>
+
+          <%!-- Benefícios (apenas no modo edição) --%>
+          <div :if={@live_action == :edit} class="border-t border-base-200 pt-5">
+            <h3 class="text-sm font-semibold text-base-content mb-3">Benefícios</h3>
+
+            <%!-- Lista de benefícios existentes --%>
+            <div class="space-y-2 mb-4">
+              <div
+                :if={@membership_type.benefits == []}
+                class="text-sm text-base-content/40 italic"
+              >
+                Nenhum benefício configurado.
+              </div>
+
+              <div
+                :for={benefit <- @membership_type.benefits}
+                id={"benefit-#{benefit.id}"}
+                class="flex items-center justify-between gap-3 rounded-lg bg-base-200 px-3 py-2 text-sm"
+              >
+                <div class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-xs">{benefit_label(benefit.benefit_type)}</span>
+                  <span class="text-base-content font-medium">{benefit_value_display(benefit)}</span>
+                </div>
+                <button
+                  type="button"
+                  phx-click="delete_benefit"
+                  phx-value-id={benefit.id}
+                  class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-error-content"
+                  aria-label="Remover benefício"
+                >
+                  <.icon name="hero-x-mark" class="size-3.5" />
+                </button>
+              </div>
+            </div>
+
+            <%!-- Formulário para adicionar novo benefício --%>
+            <.form
+              for={@benefit_form}
+              id="benefit-form"
+              phx-change="validate_benefit"
+              phx-submit="add_benefit"
+              class="rounded-lg border border-base-300 p-3 space-y-3"
+            >
+              <p class="text-xs font-semibold text-base-content/50 uppercase tracking-wider">
+                Adicionar Benefício
+              </p>
+
+              <.input
+                field={@benefit_form[:benefit_type]}
+                type="select"
+                label="Tipo"
+                options={[
+                  {"Desconto Percentual (basis points: 1500 = 15%)", "percentage_discount"},
+                  {"Desconto Fixo (centavos: 500 = R$ 5,00)", "fixed_discount"},
+                  {"Acesso a Item", "item_access"}
+                ]}
+                prompt="Selecione o tipo..."
+              />
+
+              <div :if={@benefit_form[:benefit_type].value in ["percentage_discount", "fixed_discount"]}>
+                <.input
+                  field={@benefit_form[:value]}
+                  type="number"
+                  label="Valor"
+                  min="1"
+                  placeholder={
+                    if @benefit_form[:benefit_type].value == "percentage_discount",
+                      do: "Ex: 1500 = 15%",
+                      else: "Ex: 500 = R$ 5,00"
+                  }
+                />
+              </div>
+
+              <div class="flex justify-end">
+                <button type="submit" class="btn btn-outline btn-sm gap-1" phx-disable-with="Adicionando...">
+                  <.icon name="hero-plus" class="size-3.5" /> Adicionar
+                </button>
+              </div>
+            </.form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Modal: Conceder Associação --%>
+  <div :if={@live_action == :grant}>
+    <div
+      id="grant-modal-backdrop"
+      class="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+      phx-click="close_modal"
+    >
+    </div>
+
+    <div
+      id="grant-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        class="w-full max-w-md bg-base-100 rounded-2xl shadow-2xl border border-base-200 overflow-hidden"
+        phx-click-away="close_modal"
+      >
+        <%!-- Cabeçalho do modal --%>
+        <div class="flex items-center justify-between px-6 py-4 border-b border-base-200">
+          <div>
+            <h2 class="text-lg font-bold text-base-content">Conceder Associação</h2>
+            <p class="text-sm text-base-content/60 mt-0.5">
+              {@membership_type && @membership_type.name}
+            </p>
+          </div>
+          <button
+            type="button"
+            phx-click="close_modal"
+            class="btn btn-ghost btn-sm btn-circle"
+            aria-label="Fechar"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
+
+        <%!-- Corpo do modal --%>
+        <div class="px-6 py-5">
+          <.form
+            for={@grant_form}
+            id="grant-form"
+            phx-submit="grant"
+            class="space-y-4"
+          >
+            <.input
+              field={@grant_form[:email]}
+              type="email"
+              label="E-mail do cliente"
+              placeholder="cliente@exemplo.com"
+              required
+            />
+            <p class="text-xs text-base-content/50 -mt-2">
+              O cliente precisa ter uma conta cadastrada na plataforma.
+            </p>
+
+            <div class="flex justify-end gap-3 pt-2">
+              <button type="button" phx-click="close_modal" class="btn btn-ghost btn-sm">
+                Cancelar
+              </button>
+              <.button type="submit" variant="primary" phx-disable-with="Concedendo...">
+                Conceder Associação
+              </.button>
+            </div>
+          </.form>
+        </div>
+      </div>
+    </div>
+  </div>
+</.dashboard_layout>

--- a/pretex/lib/pretex_web/live/customer_live/memberships.ex
+++ b/pretex/lib/pretex_web/live/customer_live/memberships.ex
@@ -1,0 +1,160 @@
+defmodule PretexWeb.CustomerLive.Memberships do
+  use PretexWeb, :live_view
+
+  alias Pretex.Memberships
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.customer_layout current_scope={@current_scope} current_path="/account/memberships" flash={@flash}>
+      <div class="mx-auto max-w-3xl">
+        <div class="mb-8">
+          <h1 class="text-2xl font-bold tracking-tight text-base-content">Minhas Associações</h1>
+          <p class="mt-1 text-sm text-base-content/60">
+            Associações ativas e seus benefícios.
+          </p>
+        </div>
+
+        <div :if={@memberships == []} class="text-center py-20 space-y-6">
+          <div class="flex justify-center">
+            <div class="rounded-full bg-base-200 p-6">
+              <.icon name="hero-identification" class="size-16 text-base-content/40" />
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <h2 class="text-xl font-semibold text-base-content">
+              Você ainda não possui associações
+            </h2>
+            <p class="text-base text-base-content/60 max-w-sm mx-auto">
+              Associações oferecem descontos automáticos e acesso exclusivo a itens nos eventos.
+            </p>
+          </div>
+
+          <div class="pt-2">
+            <.link
+              navigate={~p"/events"}
+              class="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-content shadow-sm hover:brightness-110 transition-all duration-150"
+            >
+              <.icon name="hero-magnifying-glass" class="size-4" /> Explorar Eventos
+            </.link>
+          </div>
+        </div>
+
+        <div :if={@memberships != []} id="memberships-list" class="space-y-4">
+          <div
+            :for={membership <- @memberships}
+            id={"membership-#{membership.id}"}
+            class="rounded-2xl border border-base-200 bg-base-100 shadow-sm overflow-hidden"
+          >
+            <%!-- Cabeçalho do card --%>
+            <div class="flex items-center justify-between px-5 py-4 border-b border-base-200 bg-base-200/30">
+              <div class="flex items-center gap-3">
+                <div class="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+                  <.icon name="hero-identification" class="size-5 text-primary" />
+                </div>
+                <div>
+                  <p class="font-semibold text-base-content">
+                    {membership.membership_type.name}
+                  </p>
+                  <p
+                    :if={membership.membership_type.description}
+                    class="text-xs text-base-content/50 mt-0.5"
+                  >
+                    {membership.membership_type.description}
+                  </p>
+                </div>
+              </div>
+
+              <%= cond do %>
+                <% expired?(membership) -> %>
+                  <span class="badge badge-error badge-sm font-semibold">Expirado</span>
+                <% membership.status == "active" -> %>
+                  <span class="badge badge-success badge-sm font-semibold">Ativo</span>
+                <% true -> %>
+                  <span class="badge badge-ghost badge-sm font-semibold">
+                    {String.capitalize(membership.status)}
+                  </span>
+              <% end %>
+            </div>
+
+            <%!-- Corpo do card --%>
+            <div class="px-5 py-4 space-y-4">
+              <%!-- Validade --%>
+              <div class="flex items-center gap-3 text-sm">
+                <.icon name="hero-calendar-days" class="size-4 text-primary shrink-0" />
+                <div>
+                  <span class="text-base-content/60">Válido de </span>
+                  <span class="font-medium text-base-content">
+                    {format_date(membership.starts_at)}
+                  </span>
+                  <span class="text-base-content/60"> até </span>
+                  <span class={[
+                    "font-medium",
+                    expired?(membership) && "text-error",
+                    !expired?(membership) && "text-base-content"
+                  ]}>
+                    {format_date(membership.expires_at)}
+                  </span>
+                </div>
+              </div>
+
+              <%!-- Benefícios --%>
+              <div :if={membership.membership_type.benefits != []}>
+                <p class="text-xs font-semibold text-base-content/40 uppercase tracking-wider mb-2">
+                  Benefícios
+                </p>
+                <div class="space-y-1.5">
+                  <div
+                    :for={benefit <- membership.membership_type.benefits}
+                    class="flex items-center gap-2 text-sm"
+                  >
+                    <.icon name="hero-check-circle" class="size-4 text-success shrink-0" />
+                    <span class="text-base-content">{benefit_description(benefit)}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </.customer_layout>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :page_title, "Minhas Associações")}
+  end
+
+  @impl true
+  def handle_params(_params, _uri, socket) do
+    customer = socket.assigns.current_scope.customer
+    memberships = Memberships.list_active_memberships(customer)
+    {:noreply, assign(socket, :memberships, memberships)}
+  end
+
+  defp expired?(%{expires_at: expires_at}) do
+    DateTime.compare(expires_at, DateTime.utc_now()) == :lt
+  end
+
+  defp format_date(%DateTime{} = dt), do: Calendar.strftime(dt, "%d/%m/%Y")
+  defp format_date(_), do: "—"
+
+  defp benefit_description(%{benefit_type: "percentage_discount", value: v}) when is_integer(v) do
+    whole = div(v, 100)
+    frac = rem(v, 100)
+    "#{whole},#{String.pad_leading(to_string(frac), 2, "0")}% de desconto automático nos pedidos"
+  end
+
+  defp benefit_description(%{benefit_type: "fixed_discount", value: v}) when is_integer(v) do
+    whole = div(v, 100)
+    frac = rem(v, 100)
+    "R$ #{whole},#{String.pad_leading(to_string(frac), 2, "0")} de desconto fixo nos pedidos"
+  end
+
+  defp benefit_description(%{benefit_type: "item_access"}),
+    do: "Acesso a itens exclusivos para membros"
+
+  defp benefit_description(_), do: "Benefício especial"
+end

--- a/pretex/lib/pretex_web/live/events_live/show.ex
+++ b/pretex/lib/pretex_web/live/events_live/show.ex
@@ -3,6 +3,7 @@ defmodule PretexWeb.EventsLive.Show do
 
   alias Pretex.Events
   alias Pretex.Catalog
+  alias Pretex.Memberships
   alias Pretex.Orders
 
   @impl true
@@ -78,7 +79,15 @@ defmodule PretexWeb.EventsLive.Show do
                 <div class="flex-1 min-w-0">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <h3 class="font-semibold text-base-content">{item.name}</h3>
+                      <div class="flex items-center gap-2">
+                        <h3 class="font-semibold text-base-content">{item.name}</h3>
+                        <span
+                          :if={MapSet.member?(@restricted_item_ids, item.id)}
+                          class="badge badge-warning badge-xs font-semibold"
+                        >
+                          Membros
+                        </span>
+                      </div>
                       <p
                         :if={item.description}
                         class="mt-1 text-sm text-base-content/60 leading-relaxed"
@@ -214,11 +223,15 @@ defmodule PretexWeb.EventsLive.Show do
 
     items_by_category = group_items_by_category(items, categories)
 
+    item_ids = Enum.map(items, & &1.id)
+    restricted_ids = Memberships.restricted_item_ids(item_ids)
+
     socket =
       socket
       |> assign(:page_title, event.name)
       |> assign(:event, event)
       |> assign(:items_by_category, items_by_category)
+      |> assign(:restricted_item_ids, restricted_ids)
       |> assign(:cart, nil)
       |> assign(:cart_total, 0)
 
@@ -279,23 +292,33 @@ defmodule PretexWeb.EventsLive.Show do
       if is_nil(cart) do
         {:noreply, put_flash(socket, :error, "Could not create cart.")}
       else
-        case Orders.add_to_cart(cart, item) do
-          {:ok, _cart_item} ->
-            updated_cart = Orders.get_cart_by_token(cart.session_token)
+        with :ok <- check_membership_access(socket, item) do
+          case Orders.add_to_cart(cart, item) do
+            {:ok, _cart_item} ->
+              updated_cart = Orders.get_cart_by_token(cart.session_token)
 
-            socket =
-              socket
-              |> assign(:cart, updated_cart)
-              |> assign(:cart_total, Orders.cart_total(updated_cart))
-              |> push_patch(
-                to: ~p"/events/#{event.slug}?cart_token=#{cart.session_token}",
-                replace: true
-              )
+              socket =
+                socket
+                |> assign(:cart, updated_cart)
+                |> assign(:cart_total, Orders.cart_total(updated_cart))
+                |> push_patch(
+                  to: ~p"/events/#{event.slug}?cart_token=#{cart.session_token}",
+                  replace: true
+                )
 
-            {:noreply, socket}
+              {:noreply, socket}
 
-          {:error, _changeset} ->
-            {:noreply, put_flash(socket, :error, "Could not add item to cart.")}
+            {:error, _changeset} ->
+              {:noreply, put_flash(socket, :error, "Could not add item to cart.")}
+          end
+        else
+          {:error, :membership_required} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               "Este item é exclusivo para membros. Adquira uma associação para ter acesso."
+             )}
         end
       end
     end
@@ -333,6 +356,31 @@ defmodule PretexWeb.EventsLive.Show do
   # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------
+
+  defp check_membership_access(socket, item) do
+    restricted_ids = socket.assigns.restricted_item_ids
+
+    if MapSet.member?(restricted_ids, item.id) do
+      customer = socket.assigns.current_scope && socket.assigns.current_scope.customer
+
+      cond do
+        is_nil(customer) ->
+          {:error, :membership_required}
+
+        Memberships.customer_has_item_access?(
+          customer.id,
+          socket.assigns.event.organization_id,
+          item.id
+        ) ->
+          :ok
+
+        true ->
+          {:error, :membership_required}
+      end
+    else
+      :ok
+    end
+  end
 
   defp group_items_by_category(items, categories) do
     category_map = Map.new(categories, &{&1.id, &1})

--- a/pretex/lib/pretex_web/router.ex
+++ b/pretex/lib/pretex_web/router.ex
@@ -188,6 +188,11 @@ defmodule PretexWeb.Router do
       live("/organizations/:org_id/gift-cards/new", GiftCardLive.Index, :new)
       live("/organizations/:org_id/gift-cards/:id/edit", GiftCardLive.Index, :edit)
       live("/organizations/:org_id/gift-cards/:id/top-up", GiftCardLive.Index, :top_up)
+
+      live("/organizations/:org_id/memberships", MembershipLive.Index, :index)
+      live("/organizations/:org_id/memberships/new", MembershipLive.Index, :new)
+      live("/organizations/:org_id/memberships/:id/edit", MembershipLive.Index, :edit)
+      live("/organizations/:org_id/memberships/:id/grant", MembershipLive.Index, :grant)
     end
   end
 
@@ -216,6 +221,7 @@ defmodule PretexWeb.Router do
       live("/customers/settings", CustomerLive.Settings, :edit)
       live("/customers/settings/confirm-email/:token", CustomerLive.Settings, :confirm_email)
       live("/account/orders", CustomerLive.Orders, :index)
+      live("/account/memberships", CustomerLive.Memberships, :index)
       live("/account/privacy", CustomerLive.Privacy, :index)
     end
 


### PR DESCRIPTION
# Summary

Closes #19

This PR completes Story 018: Memberships by adding the organizer admin UI, customer-facing memberships page, and enforcement of item_access membership benefits in the event catalog —
building on the backend context, database schema, and checkout integration landed in #47.

## What's included

Admin UI — Membership type management

* New MembershipLive.Index at /admin/organizations/:org_id/memberships
* Create, edit, delete, and toggle active/inactive membership types
* Inline benefit management inside the edit modal: add/remove percentage_discount, fixed_discount, and item_access benefits
* Manual grant modal: look up a customer by email and grant them a membership instantly
* "Associações" entry added to the org admin sidebar

Customer memberships page

* New CustomerLive.Memberships at /account/memberships
* Lists all active memberships with validity dates, status badge (correctly shows "Expirado" when expires_at has passed, even if the DB status hasn't been updated yet), and
human-readable benefit descriptions
* "Associações" and "Meus Pedidos" nav links added to the customer layout navbar

item_access benefit enforcement

* New context functions: item_requires_membership?/1, restricted_item_ids/1, customer_has_item_access?/3
* restricted_item_ids/1 is called once at mount (single bulk query — no N+1) and stored as a MapSet assign
* A "Membros" badge is rendered on restricted items in the event catalog
* Before add_to_cart, a membership access check runs: guests and non-members see a flash error; valid members proceed normally

## Acceptance criteria

| AC | Status |
| --- | --- |
| AC1 — Create membership types with validity and benefits | ✅ |
| AC2 — Sell via checkout (existing) / grant manually | ✅ |
| AC3 — Membership discount applied first in pricing chain (existing) | ✅ |
| AC4 — Customer account view of memberships, validity dates, benefits | ✅ |
| Edge — Expired membership shown correctly in customer page | ✅ |
| Edge — Cross-org membership benefits not applied (existing) | ✅ |
| Edge — Best benefit selected when multiple memberships overlap (existing) | ✅ |
| Edge — item_access restricted items blocked for non-members | ✅ |

## Test plan

* Create a membership type with a percentage_discount benefit and verify it appears in the admin list
* Edit the membership type and add a fixed_discount benefit inline; delete one benefit
* Use the grant modal to assign a membership to a customer by email; verify it appears on their /account/memberships page
* Confirm expired memberships show the "Expirado" badge on the customer page
* Mark an item as item_access-restricted via a membership benefit; verify the "Membros" badge appears on the event page
* Attempt to add a restricted item to cart as a guest → expect membership required flash error
* Attempt to add a restricted item as a logged-in customer without the membership → expect flash error
* Add the restricted item as a customer with the qualifying active membership → expect success