### PR TITLE
feat: Story 020 — Check-in with QR scanning and real-time counter

### DIFF
--- a/pretex/assets/js/app.js
+++ b/pretex/assets/js/app.js
@@ -23,13 +23,14 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/pretex"
+import QRScanner from "./hooks/qr_scanner"
 import topbar from "../vendor/topbar"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks},
+  hooks: {...colocatedHooks, QRScanner},
 })
 
 // Show progress bar on live navigation and form submits

--- a/pretex/assets/js/hooks/qr_scanner.js
+++ b/pretex/assets/js/hooks/qr_scanner.js
@@ -1,0 +1,66 @@
+import { Html5Qrcode } from "html5-qrcode"
+
+const QRScanner = {
+  mounted() {
+    this.scanner = null
+    this.scanning = false
+    this.cooldown = false
+
+    this.startButton = this.el.querySelector("[data-start-scan]")
+    this.stopButton = this.el.querySelector("[data-stop-scan]")
+    this.readerEl = this.el.querySelector("[data-qr-reader]")
+
+    if (this.startButton) {
+      this.startButton.addEventListener("click", () => this.startScan())
+    }
+    if (this.stopButton) {
+      this.stopButton.addEventListener("click", () => this.stopScan())
+    }
+  },
+
+  async startScan() {
+    if (this.scanning) return
+
+    const readerId = this.readerEl.id
+    this.scanner = new Html5Qrcode(readerId)
+
+    try {
+      await this.scanner.start(
+        { facingMode: "environment" },
+        { fps: 10, qrbox: { width: 250, height: 250 } },
+        (decodedText) => {
+          if (this.cooldown) return
+          this.cooldown = true
+          this.pushEvent("scan", { code: decodedText })
+          setTimeout(() => { this.cooldown = false }, 2000)
+        },
+        (_errorMessage) => {}
+      )
+
+      this.scanning = true
+      if (this.startButton) this.startButton.classList.add("hidden")
+      if (this.stopButton) this.stopButton.classList.remove("hidden")
+    } catch (err) {
+      console.error("QR Scanner error:", err)
+      this.pushEvent("scan_error", { message: "Camera access denied or unavailable" })
+    }
+  },
+
+  async stopScan() {
+    if (!this.scanning || !this.scanner) return
+
+    try {
+      await this.scanner.stop()
+    } catch (_) {}
+
+    this.scanning = false
+    if (this.startButton) this.startButton.classList.remove("hidden")
+    if (this.stopButton) this.stopButton.classList.add("hidden")
+  },
+
+  async destroyed() {
+    await this.stopScan()
+  }
+}
+
+export default QRScanner

--- a/pretex/assets/package-lock.json
+++ b/pretex/assets/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "assets",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "assets",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "html5-qrcode": "^2.3.8"
+      }
+    },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/pretex/assets/package.json
+++ b/pretex/assets/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "assets",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "html5-qrcode": "^2.3.8"
+  }
+}

--- a/pretex/lib/pretex/check_ins.ex
+++ b/pretex/lib/pretex/check_ins.ex
@@ -115,8 +115,9 @@ defmodule Pretex.CheckIns do
     |> join(:inner, [oi], o in Order, on: oi.order_id == o.id)
     |> where([oi, o], o.event_id == ^event_id and o.status == "confirmed")
     |> where(
-      [oi, _o],
-      ilike(oi.attendee_name, ^term) or ilike(oi.attendee_email, ^term)
+      [oi, o],
+      ilike(oi.attendee_name, ^term) or ilike(oi.attendee_email, ^term) or
+        ilike(o.name, ^term) or ilike(o.email, ^term)
     )
     |> preload([oi, o], order: o, item: [])
     |> Repo.all()

--- a/pretex/lib/pretex/check_ins.ex
+++ b/pretex/lib/pretex/check_ins.ex
@@ -1,0 +1,151 @@
+defmodule Pretex.CheckIns do
+  @moduledoc "Manages event check-in operations."
+
+  import Ecto.Query
+
+  alias Pretex.Repo
+  alias Pretex.CheckIns.CheckIn
+  alias Pretex.Orders.{Order, OrderItem}
+
+  def checkin_topic(event_id), do: "checkins:event:#{event_id}"
+
+  def check_in_by_ticket_code(event_id, ticket_code, operator_id) do
+    order_item =
+      OrderItem
+      |> join(:inner, [oi], o in Order, on: oi.order_id == o.id)
+      |> where([oi, _o], oi.ticket_code == ^ticket_code)
+      |> preload([oi, o], order: o)
+      |> Repo.one()
+
+    case order_item do
+      nil ->
+        {:error, :invalid_ticket}
+
+      %{order: %{event_id: ^event_id}} = oi ->
+        validate_and_check_in(oi, event_id, operator_id)
+
+      _wrong_event ->
+        {:error, :wrong_event}
+    end
+  end
+
+  defp validate_and_check_in(%{order: %{status: status}}, _event_id, _operator_id)
+       when status != "confirmed" do
+    {:error, :ticket_cancelled}
+  end
+
+  defp validate_and_check_in(order_item, event_id, operator_id) do
+    existing =
+      CheckIn
+      |> where(
+        [c],
+        c.order_item_id == ^order_item.id and c.event_id == ^event_id and is_nil(c.annulled_at)
+      )
+      |> Repo.one()
+
+    case existing do
+      nil ->
+        insert_check_in(order_item.id, event_id, operator_id)
+
+      _already ->
+        {:error, :already_checked_in}
+    end
+  end
+
+  defp insert_check_in(order_item_id, event_id, operator_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    result =
+      %CheckIn{}
+      |> CheckIn.changeset(%{checked_in_at: now})
+      |> Ecto.Changeset.put_change(:order_item_id, order_item_id)
+      |> Ecto.Changeset.put_change(:event_id, event_id)
+      |> Ecto.Changeset.put_change(:checked_in_by_id, operator_id)
+      |> Repo.insert()
+
+    case result do
+      {:ok, check_in} ->
+        broadcast_check_in_update(event_id)
+        {:ok, check_in}
+
+      {:error, changeset} ->
+        if has_unique_constraint_error?(changeset) do
+          {:error, :already_checked_in}
+        else
+          {:error, changeset}
+        end
+    end
+  end
+
+  defp has_unique_constraint_error?(changeset) do
+    Enum.any?(changeset.errors, fn
+      {_field, {_msg, opts}} when is_list(opts) -> Keyword.get(opts, :constraint) == :unique
+      _ -> false
+    end)
+  end
+
+  def annul_check_in(check_in_id, operator_id) do
+    check_in = Repo.get!(CheckIn, check_in_id)
+
+    if check_in.annulled_at do
+      {:error, :already_annulled}
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+      result =
+        check_in
+        |> Ecto.Changeset.change(annulled_at: now, annulled_by_id: operator_id)
+        |> Repo.update()
+
+      case result do
+        {:ok, annulled} ->
+          broadcast_check_in_update(annulled.event_id)
+          {:ok, annulled}
+
+        error ->
+          error
+      end
+    end
+  end
+
+  def search_attendees(event_id, query) do
+    term = "%#{query}%"
+
+    OrderItem
+    |> join(:inner, [oi], o in Order, on: oi.order_id == o.id)
+    |> where([oi, o], o.event_id == ^event_id and o.status == "confirmed")
+    |> where(
+      [oi, _o],
+      ilike(oi.attendee_name, ^term) or ilike(oi.attendee_email, ^term)
+    )
+    |> preload([oi, o], order: o, item: [])
+    |> Repo.all()
+  end
+
+  def get_check_in_count(event_id) do
+    CheckIn
+    |> where([c], c.event_id == ^event_id and is_nil(c.annulled_at))
+    |> Repo.aggregate(:count)
+  end
+
+  def get_total_tickets(event_id) do
+    OrderItem
+    |> join(:inner, [oi], o in Order, on: oi.order_id == o.id)
+    |> where([oi, o], o.event_id == ^event_id and o.status == "confirmed")
+    |> Repo.aggregate(:sum, :quantity) || 0
+  end
+
+  def get_active_check_in(order_item_id, event_id) do
+    CheckIn
+    |> where(
+      [c],
+      c.order_item_id == ^order_item_id and c.event_id == ^event_id and is_nil(c.annulled_at)
+    )
+    |> Repo.one()
+  end
+
+  defp broadcast_check_in_update(event_id) do
+    count = get_check_in_count(event_id)
+    Phoenix.PubSub.broadcast(Pretex.PubSub, checkin_topic(event_id), {:check_in_updated, count})
+  end
+end

--- a/pretex/lib/pretex/check_ins/check_in.ex
+++ b/pretex/lib/pretex/check_ins/check_in.ex
@@ -1,0 +1,22 @@
+defmodule Pretex.CheckIns.CheckIn do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "check_ins" do
+    field(:checked_in_at, :utc_datetime_usec)
+    field(:annulled_at, :utc_datetime_usec)
+
+    belongs_to(:order_item, Pretex.Orders.OrderItem)
+    belongs_to(:event, Pretex.Events.Event)
+    belongs_to(:checked_in_by, Pretex.Accounts.User, foreign_key: :checked_in_by_id)
+    belongs_to(:annulled_by, Pretex.Accounts.User, foreign_key: :annulled_by_id)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(check_in, attrs) do
+    check_in
+    |> cast(attrs, [:checked_in_at, :annulled_at])
+    |> validate_required([:checked_in_at])
+  end
+end

--- a/pretex/lib/pretex/events/event.ex
+++ b/pretex/lib/pretex/events/event.ex
@@ -19,6 +19,7 @@ defmodule Pretex.Events.Event do
     field(:accent_color, :string, default: "#f43f5e")
 
     field(:is_series, :boolean, default: false)
+    field(:multi_entry, :boolean, default: false)
 
     belongs_to(:organization, Pretex.Organizations.Organization)
     has_many(:sub_events, Pretex.Events.SubEvent, foreign_key: :parent_event_id)
@@ -38,7 +39,8 @@ defmodule Pretex.Events.Event do
       :banner_url,
       :primary_color,
       :accent_color,
-      :is_series
+      :is_series,
+      :multi_entry
     ])
     |> validate_required([:name, :starts_at, :ends_at])
     |> validate_length(:name, min: 2, max: 255)

--- a/pretex/lib/pretex_web/live/admin/check_in_live/index.ex
+++ b/pretex/lib/pretex_web/live/admin/check_in_live/index.ex
@@ -1,0 +1,187 @@
+defmodule PretexWeb.Admin.CheckInLive.Index do
+  use PretexWeb, :live_view
+
+  alias Pretex.CheckIns
+  alias Pretex.Events
+  alias Pretex.Organizations
+
+  @impl true
+  def mount(%{"org_id" => org_id, "event_id" => event_id}, _session, socket) do
+    org = Organizations.get_organization!(org_id)
+    event = Events.get_event!(event_id)
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Pretex.PubSub, CheckIns.checkin_topic(event.id))
+    end
+
+    checked_in_count = CheckIns.get_check_in_count(event.id)
+    total_tickets = CheckIns.get_total_tickets(event.id)
+
+    socket =
+      socket
+      |> assign(:org, org)
+      |> assign(:event, event)
+      |> assign(:checked_in_count, checked_in_count)
+      |> assign(:total_tickets, total_tickets)
+      |> assign(:scan_result, nil)
+      |> assign(:search_query, "")
+      |> assign(:search_results, [])
+      |> assign(:page_title, "Check-in — #{event.name}")
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("scan", %{"code" => code}, socket) do
+    event = socket.assigns.event
+    operator_id = socket.assigns.current_user.id
+
+    result = CheckIns.check_in_by_ticket_code(event.id, code, operator_id)
+
+    scan_result =
+      case result do
+        {:ok, check_in} ->
+          order_item =
+            Pretex.Repo.preload(check_in, order_item: [:item]).order_item
+
+          %{
+            status: :success,
+            message: "Check-in realizado!",
+            attendee_name: order_item.attendee_name,
+            item_name: order_item.item.name,
+            ticket_code: order_item.ticket_code
+          }
+
+        {:error, :invalid_ticket} ->
+          %{status: :error, message: "Ingresso inválido", attendee_name: nil}
+
+        {:error, :wrong_event} ->
+          %{status: :error, message: "Ingresso não pertence a este evento", attendee_name: nil}
+
+        {:error, :ticket_cancelled} ->
+          %{status: :error, message: "Ingresso cancelado", attendee_name: nil}
+
+        {:error, :already_checked_in} ->
+          %{status: :error, message: "Já foi feito check-in", attendee_name: nil}
+      end
+
+    socket =
+      socket
+      |> assign(:scan_result, scan_result)
+      |> assign(:checked_in_count, CheckIns.get_check_in_count(event.id))
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("scan_error", %{"message" => msg}, socket) do
+    {:noreply, put_flash(socket, :error, msg)}
+  end
+
+  @impl true
+  def handle_event("search", %{"query" => query}, socket) do
+    results =
+      if String.length(query) >= 2 do
+        attendees = CheckIns.search_attendees(socket.assigns.event.id, query)
+
+        Enum.map(attendees, fn oi ->
+          active_ci = CheckIns.get_active_check_in(oi.id, socket.assigns.event.id)
+
+          %{
+            order_item_id: oi.id,
+            attendee_name: oi.attendee_name,
+            attendee_email: oi.attendee_email,
+            ticket_code: oi.ticket_code,
+            item_name: oi.item.name,
+            checked_in: active_ci != nil,
+            check_in_id: active_ci && active_ci.id
+          }
+        end)
+      else
+        []
+      end
+
+    {:noreply, assign(socket, search_query: query, search_results: results)}
+  end
+
+  @impl true
+  def handle_event("check_in_attendee", %{"ticket-code" => code}, socket) do
+    event = socket.assigns.event
+    operator_id = socket.assigns.current_user.id
+
+    case CheckIns.check_in_by_ticket_code(event.id, code, operator_id) do
+      {:ok, _} ->
+        results = refresh_search(socket)
+
+        {:noreply,
+         socket
+         |> assign(:search_results, results)
+         |> assign(:checked_in_count, CheckIns.get_check_in_count(event.id))
+         |> put_flash(:info, "Check-in realizado!")}
+
+      {:error, reason} ->
+        msg =
+          case reason do
+            :already_checked_in -> "Já foi feito check-in"
+            :ticket_cancelled -> "Ingresso cancelado"
+            _ -> "Erro ao fazer check-in"
+          end
+
+        {:noreply, put_flash(socket, :error, msg)}
+    end
+  end
+
+  @impl true
+  def handle_event("annul_check_in", %{"check-in-id" => check_in_id}, socket) do
+    operator_id = socket.assigns.current_user.id
+    {id, _} = Integer.parse(check_in_id)
+
+    case CheckIns.annul_check_in(id, operator_id) do
+      {:ok, _} ->
+        results = refresh_search(socket)
+
+        {:noreply,
+         socket
+         |> assign(:search_results, results)
+         |> assign(:checked_in_count, CheckIns.get_check_in_count(socket.assigns.event.id))
+         |> put_flash(:info, "Check-in anulado.")}
+
+      {:error, :already_annulled} ->
+        {:noreply, put_flash(socket, :error, "Check-in já foi anulado.")}
+    end
+  end
+
+  @impl true
+  def handle_event("clear_scan_result", _, socket) do
+    {:noreply, assign(socket, :scan_result, nil)}
+  end
+
+  @impl true
+  def handle_info({:check_in_updated, count}, socket) do
+    {:noreply, assign(socket, :checked_in_count, count)}
+  end
+
+  defp refresh_search(socket) do
+    query = socket.assigns.search_query
+
+    if String.length(query) >= 2 do
+      attendees = CheckIns.search_attendees(socket.assigns.event.id, query)
+
+      Enum.map(attendees, fn oi ->
+        active_ci = CheckIns.get_active_check_in(oi.id, socket.assigns.event.id)
+
+        %{
+          order_item_id: oi.id,
+          attendee_name: oi.attendee_name,
+          attendee_email: oi.attendee_email,
+          ticket_code: oi.ticket_code,
+          item_name: oi.item.name,
+          checked_in: active_ci != nil,
+          check_in_id: active_ci && active_ci.id
+        }
+      end)
+    else
+      []
+    end
+  end
+end

--- a/pretex/lib/pretex_web/live/admin/check_in_live/index.html.heex
+++ b/pretex/lib/pretex_web/live/admin/check_in_live/index.html.heex
@@ -1,0 +1,143 @@
+<.dashboard_layout
+  current_path={~p"/admin/organizations/#{@org}/events/#{@event}/check-in"}
+  org={@org}
+  flash={@flash}
+>
+  <div class="mx-auto max-w-2xl px-4 py-8">
+    <%!-- Back link --%>
+    <div class="mb-6">
+      <.link
+        navigate={~p"/admin/organizations/#{@org}/events/#{@event}"}
+        class="inline-flex items-center gap-1 text-sm text-base-content/60 hover:text-primary transition-colors"
+      >
+        <.icon name="hero-arrow-left" class="size-4" /> Voltar ao Evento
+      </.link>
+    </div>
+
+    <div class="space-y-6">
+      <%!-- Stats bar --%>
+      <div class="stats shadow w-full bg-base-100">
+        <div class="stat">
+          <div class="stat-figure text-primary">
+            <.icon name="hero-qr-code" class="size-8" />
+          </div>
+          <div class="stat-title">Check-ins</div>
+          <div class="stat-value text-primary">{@checked_in_count}</div>
+          <div class="stat-desc">de {@total_tickets || 0} ingressos confirmados</div>
+        </div>
+      </div>
+
+      <%!-- Scan result feedback --%>
+      <div
+        :if={@scan_result}
+        class={[
+          "alert shadow-lg",
+          if(@scan_result.status == :success, do: "alert-success", else: "alert-error")
+        ]}
+      >
+        <div class="flex items-center gap-3">
+          <.icon
+            name={if(@scan_result.status == :success, do: "hero-check-circle", else: "hero-x-circle")}
+            class="size-8 shrink-0"
+          />
+          <div>
+            <h3 class="font-bold text-lg">{@scan_result.message}</h3>
+            <p :if={@scan_result.attendee_name} class="text-sm">
+              {@scan_result.attendee_name}
+              <span :if={@scan_result[:item_name]} class="opacity-70">
+                — {@scan_result.item_name}
+              </span>
+            </p>
+          </div>
+        </div>
+        <button class="btn btn-sm btn-ghost" phx-click="clear_scan_result">
+          <.icon name="hero-x-mark" class="size-4" />
+        </button>
+      </div>
+
+      <%!-- QR Scanner --%>
+      <div class="card bg-base-100 shadow-sm border border-base-200">
+        <div class="card-body">
+          <h2 class="card-title text-base">
+            <.icon name="hero-qr-code" class="size-5" /> Scanner QR Code
+          </h2>
+          <div id="qr-scanner-container" phx-hook="QRScanner">
+            <div id="qr-reader" data-qr-reader class="w-full rounded-lg overflow-hidden"></div>
+            <div class="mt-3 flex gap-2">
+              <button data-start-scan class="btn btn-primary btn-sm gap-2">
+                <.icon name="hero-camera" class="size-4" /> Iniciar Câmera
+              </button>
+              <button data-stop-scan class="btn btn-ghost btn-sm gap-2 hidden">
+                <.icon name="hero-stop" class="size-4" /> Parar Câmera
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <%!-- Manual search --%>
+      <div class="card bg-base-100 shadow-sm border border-base-200">
+        <div class="card-body">
+          <h2 class="card-title text-base">
+            <.icon name="hero-magnifying-glass" class="size-5" /> Buscar Participante
+          </h2>
+          <form phx-change="search" phx-submit="search">
+            <input
+              type="text"
+              name="query"
+              value={@search_query}
+              placeholder="Nome ou email do participante..."
+              class="input input-bordered w-full"
+              phx-debounce="300"
+            />
+          </form>
+
+          <div :if={@search_results != []} class="mt-4 space-y-2">
+            <div
+              :for={attendee <- @search_results}
+              class="flex items-center justify-between rounded-lg bg-base-200/50 px-4 py-3"
+            >
+              <div class="min-w-0 flex-1">
+                <p class="font-medium text-sm">{attendee.attendee_name || "Sem nome"}</p>
+                <p class="text-xs text-base-content/50">{attendee.attendee_email}</p>
+                <p class="text-xs text-base-content/50">
+                  {attendee.item_name} — <span class="font-mono">{attendee.ticket_code}</span>
+                </p>
+              </div>
+              <div>
+                <%= if attendee.checked_in do %>
+                  <div class="flex items-center gap-2">
+                    <span class="badge badge-success badge-sm">Checked in</span>
+                    <button
+                      phx-click="annul_check_in"
+                      phx-value-check-in-id={attendee.check_in_id}
+                      class="btn btn-ghost btn-xs text-error"
+                      data-confirm={"Anular check-in de #{attendee.attendee_name}?"}
+                    >
+                      Anular
+                    </button>
+                  </div>
+                <% else %>
+                  <button
+                    phx-click="check_in_attendee"
+                    phx-value-ticket-code={attendee.ticket_code}
+                    class="btn btn-primary btn-sm"
+                  >
+                    Check-in
+                  </button>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+          <p
+            :if={@search_query != "" && String.length(@search_query) >= 2 && @search_results == []}
+            class="mt-4 text-sm text-base-content/50 text-center"
+          >
+            Nenhum participante encontrado.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</.dashboard_layout>

--- a/pretex/lib/pretex_web/live/admin/event_live/show.html.heex
+++ b/pretex/lib/pretex_web/live/admin/event_live/show.html.heex
@@ -384,6 +384,32 @@
       </div>
     </div>
 
+    <%!-- Card de check-in --%>
+    <div class="card bg-base-100 border border-base-200 shadow-sm mb-4">
+      <div class="card-body p-6">
+        <div class="flex items-center justify-between gap-4 mb-4">
+          <h2 class="text-base font-semibold text-base-content flex items-center gap-2">
+            <.icon name="hero-qr-code" class="size-4 text-base-content/40" /> Check-in
+          </h2>
+          <.link
+            navigate={~p"/admin/organizations/#{@org}/events/#{@event}/check-in"}
+            class="btn btn-ghost btn-xs gap-1"
+          >
+            <.icon name="hero-arrow-right" class="size-3" /> Abrir Check-in
+          </.link>
+        </div>
+        <div class="flex items-start gap-3 rounded-lg bg-base-200 border border-base-300 p-4 text-sm">
+          <.icon
+            name="hero-information-circle"
+            class="size-5 shrink-0 text-base-content/40 mt-0.5"
+          />
+          <p class="text-base-content/70">
+            Escaneie QR codes ou busque participantes para validar ingressos na entrada do evento.
+          </p>
+        </div>
+      </div>
+    </div>
+
     <%!-- Card de pedidos --%>
     <div class="card bg-base-100 border border-base-200 shadow-sm mb-4">
       <div class="card-body p-6">

--- a/pretex/lib/pretex_web/live/events_live/confirmation.ex
+++ b/pretex/lib/pretex_web/live/events_live/confirmation.ex
@@ -120,6 +120,12 @@ defmodule PretexWeb.EventsLive.Confirmation do
                     <p :if={order_item.ticket_code} class="text-xs font-mono text-primary/70 mt-1">
                       # {order_item.ticket_code}
                     </p>
+                    <div
+                      :if={order_item.ticket_code && @order.status == "confirmed"}
+                      class="mt-3 flex justify-center"
+                    >
+                      {ticket_qr_svg(order_item.ticket_code) |> Phoenix.HTML.raw()}
+                    </div>
                   </div>
                   <div class="shrink-0 text-right">
                     <span class="font-semibold text-base-content text-sm">
@@ -211,5 +217,11 @@ defmodule PretexWeb.EventsLive.Confirmation do
     dollars = div(cents, 100)
     cents_part = rem(cents, 100)
     "R$ #{dollars},#{String.pad_leading(Integer.to_string(cents_part), 2, "0")}"
+  end
+
+  defp ticket_qr_svg(ticket_code) do
+    ticket_code
+    |> EQRCode.encode()
+    |> EQRCode.svg(width: 160)
   end
 end

--- a/pretex/lib/pretex_web/router.ex
+++ b/pretex/lib/pretex_web/router.ex
@@ -166,6 +166,8 @@ defmodule PretexWeb.Router do
       live("/organizations/:org_id/events/:event_id/orders/new", OrderLive.NewManual, :new_manual)
       live("/organizations/:org_id/events/:event_id/orders/:id", OrderLive.Show, :show)
 
+      live("/organizations/:org_id/events/:event_id/check-in", CheckInLive.Index, :index)
+
       live("/organizations/:org_id/events/:event_id/fees", FeeLive.Index, :index)
       live("/organizations/:org_id/events/:event_id/fees/new", FeeLive.Index, :new)
       live("/organizations/:org_id/events/:event_id/fees/:id/edit", FeeLive.Index, :edit)

--- a/pretex/priv/repo/migrations/20260323174408_create_check_ins.exs
+++ b/pretex/priv/repo/migrations/20260323174408_create_check_ins.exs
@@ -1,0 +1,28 @@
+defmodule Pretex.Repo.Migrations.CreateCheckIns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events) do
+      add :multi_entry, :boolean, default: false, null: false
+    end
+
+    create table(:check_ins) do
+      add :order_item_id, references(:order_items, on_delete: :restrict), null: false
+      add :event_id, references(:events, on_delete: :restrict), null: false
+      add :checked_in_by_id, references(:users, on_delete: :restrict), null: false
+      add :checked_in_at, :utc_datetime_usec, null: false
+      add :annulled_at, :utc_datetime_usec
+      add :annulled_by_id, references(:users, on_delete: :restrict)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:check_ins, [:event_id])
+    create index(:check_ins, [:order_item_id])
+
+    create unique_index(:check_ins, [:order_item_id, :event_id],
+             where: "annulled_at IS NULL",
+             name: :check_ins_active_unique
+           )
+  end
+end

--- a/pretex/test/pretex/check_ins_test.exs
+++ b/pretex/test/pretex/check_ins_test.exs
@@ -151,7 +151,10 @@ defmodule Pretex.CheckInsTest do
 
       results = CheckIns.search_attendees(event.id, "Jane")
       assert length(results) > 0
-      assert hd(results).attendee_name =~ "Jane"
+      result = hd(results)
+      # Match found via order_item.attendee_name or order.name
+      name = result.attendee_name || result.order.name
+      assert name =~ "Jane"
     end
 
     test "returns empty list when no match" do

--- a/pretex/test/pretex/check_ins_test.exs
+++ b/pretex/test/pretex/check_ins_test.exs
@@ -1,0 +1,185 @@
+defmodule Pretex.CheckInsTest do
+  use Pretex.DataCase, async: true
+
+  import Pretex.OrganizationsFixtures
+  import Pretex.EventsFixtures
+  import Pretex.CatalogFixtures
+  import Pretex.AccountsFixtures
+
+  alias Pretex.CheckIns
+  alias Pretex.CheckIns.CheckIn
+  alias Pretex.Orders
+
+  defp confirmed_order_fixture(event) do
+    {:ok, cart} = Orders.create_cart(event)
+    cart = Orders.get_cart_by_token(cart.session_token)
+    item = item_fixture(event)
+
+    {:ok, _} = Orders.add_to_cart(cart, item)
+    cart = Orders.get_cart_by_token(cart.session_token)
+
+    {:ok, order} =
+      Orders.create_order_from_cart(cart, %{
+        name: "Jane Doe",
+        email: "jane@example.com",
+        payment_method: "pix"
+      })
+
+    {:ok, order} = Orders.confirm_order(order)
+    Orders.get_order!(order.id)
+  end
+
+  describe "check_in_by_ticket_code/3" do
+    test "checks in an attendee with a valid ticket code" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      order = confirmed_order_fixture(event)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      assert {:ok, %CheckIn{} = check_in} =
+               CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+
+      assert check_in.order_item_id == order_item.id
+      assert check_in.event_id == event.id
+      assert check_in.checked_in_by_id == operator.id
+      assert check_in.checked_in_at != nil
+      assert check_in.annulled_at == nil
+    end
+
+    test "returns :invalid_ticket for unknown ticket code" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      operator = user_fixture()
+
+      assert {:error, :invalid_ticket} =
+               CheckIns.check_in_by_ticket_code(event.id, "ZZZZZZZZ", operator.id)
+    end
+
+    test "returns :wrong_event when ticket belongs to different event" do
+      org = org_fixture()
+      event1 = published_event_fixture(org)
+      event2 = published_event_fixture(org)
+      order = confirmed_order_fixture(event1)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      assert {:error, :wrong_event} =
+               CheckIns.check_in_by_ticket_code(event2.id, order_item.ticket_code, operator.id)
+    end
+
+    test "returns :ticket_cancelled when order is cancelled" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      order = confirmed_order_fixture(event)
+      {:ok, _} = Orders.cancel_order(order)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      assert {:error, :ticket_cancelled} =
+               CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+    end
+
+    test "returns :already_checked_in on duplicate check-in" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      order = confirmed_order_fixture(event)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      assert {:ok, _} =
+               CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+
+      assert {:error, :already_checked_in} =
+               CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+    end
+
+    test "allows re-check-in after annulment when multi_entry is enabled" do
+      org = org_fixture()
+      event = published_event_fixture(org, %{multi_entry: true})
+      order = confirmed_order_fixture(event)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      assert {:ok, ci1} =
+               CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+
+      assert {:ok, _} = CheckIns.annul_check_in(ci1.id, operator.id)
+
+      assert {:ok, _ci2} =
+               CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+    end
+  end
+
+  describe "annul_check_in/2" do
+    test "annuls an active check-in" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      order = confirmed_order_fixture(event)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      {:ok, check_in} =
+        CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+
+      assert {:ok, annulled} = CheckIns.annul_check_in(check_in.id, operator.id)
+      assert annulled.annulled_at != nil
+      assert annulled.annulled_by_id == operator.id
+    end
+
+    test "returns error for already-annulled check-in" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      order = confirmed_order_fixture(event)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      {:ok, check_in} =
+        CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+
+      {:ok, _} = CheckIns.annul_check_in(check_in.id, operator.id)
+
+      assert {:error, :already_annulled} = CheckIns.annul_check_in(check_in.id, operator.id)
+    end
+  end
+
+  describe "search_attendees/2" do
+    test "finds attendees by name" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      _order = confirmed_order_fixture(event)
+
+      results = CheckIns.search_attendees(event.id, "Jane")
+      assert length(results) > 0
+      assert hd(results).attendee_name =~ "Jane"
+    end
+
+    test "returns empty list when no match" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      _order = confirmed_order_fixture(event)
+
+      assert [] = CheckIns.search_attendees(event.id, "NOMATCH12345")
+    end
+  end
+
+  describe "get_check_in_count/1" do
+    test "counts active (non-annulled) check-ins" do
+      org = org_fixture()
+      event = published_event_fixture(org)
+      order = confirmed_order_fixture(event)
+      operator = user_fixture()
+      [order_item | _] = order.order_items
+
+      assert CheckIns.get_check_in_count(event.id) == 0
+
+      {:ok, check_in} =
+        CheckIns.check_in_by_ticket_code(event.id, order_item.ticket_code, operator.id)
+
+      assert CheckIns.get_check_in_count(event.id) == 1
+
+      {:ok, _} = CheckIns.annul_check_in(check_in.id, operator.id)
+      assert CheckIns.get_check_in_count(event.id) == 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements [Story 020: Check-in](https://github.com/devsnorte/ingressos/issues/12) — QR code scanning and attendee search for event entry validation.

- **QR code scanning** via browser camera (`html5-qrcode` JS hook)
- **Name/email search** with debounced input for manual check-in
- **Ticket validation** — invalid ticket, wrong event, cancelled order, duplicate check-in
- **Annul check-in** with confirmation dialog
- **Real-time attendance counter** via PubSub (updates within 2 seconds)
- **QR codes on tickets** — rendered on order confirmation page for confirmed orders
- **Concurrent check-in protection** via unique partial DB index
- **Admin navigation** — check-in card on event show page

### Files changed (14 files, ~870 lines)

| Area | Files |
|------|-------|
| **Database** | Migration: `check_ins` table + `multi_entry` on events |
| **Schema** | `CheckIn` schema, `Event` multi_entry field |
| **Context** | `Pretex.CheckIns` — check-in, annul, search, count, PubSub |
| **LiveView** | `CheckInLive.Index` — scanner + search + live counter |
| **JS** | `QRScanner` hook with `html5-qrcode` |
| **UI** | QR codes on confirmation page, check-in card on event show |
| **Tests** | 11 tests covering all check-in scenarios |

Closes #12

## Test plan

- [x] All 1487 tests pass (0 failures)
- [x] Compilation clean with `--warnings-as-errors`
- [ ] Manual: Navigate to event admin → Check-in card visible
- [ ] Manual: Check-in page loads with counter at 0
- [ ] Manual: Camera scanner detects QR codes
- [ ] Manual: Search finds attendees by name/email
- [ ] Manual: Check-in via search updates counter
- [ ] Manual: Annul reverses check-in
- [ ] Manual: Confirmation page shows QR codes for confirmed tickets