### PR TITLE
feat: Story 022 — Device Provisioning

### DIFF
--- a/pretex/lib/pretex/devices.ex
+++ b/pretex/lib/pretex/devices.ex
@@ -1,0 +1,121 @@
+defmodule Pretex.Devices do
+  @moduledoc "Manages device provisioning and authentication."
+
+  import Ecto.Query
+
+  alias Pretex.Repo
+  alias Pretex.Devices.{Device, DeviceInitToken}
+
+  @token_expiry_hours 24
+
+  def hash_token(token) do
+    :crypto.hash(:sha256, token) |> Base.encode16(case: :lower)
+  end
+
+  def generate_init_token(organization_id, user_id) do
+    code = generate_short_code()
+    hash = hash_token(code)
+
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.add(@token_expiry_hours * 3600, :second)
+      |> DateTime.truncate(:second)
+
+    %DeviceInitToken{}
+    |> DeviceInitToken.changeset(%{expires_at: expires_at})
+    |> Ecto.Changeset.put_change(:token_hash, hash)
+    |> Ecto.Changeset.put_change(:organization_id, organization_id)
+    |> Ecto.Changeset.put_change(:created_by_id, user_id)
+    |> Repo.insert()
+    |> case do
+      {:ok, _} -> {:ok, code}
+      {:error, cs} -> {:error, cs}
+    end
+  end
+
+  def provision_device(token_code, device_name) do
+    hash = hash_token(token_code)
+
+    case Repo.get_by(DeviceInitToken, token_hash: hash) do
+      nil ->
+        {:error, :invalid_token}
+
+      %{used_at: used_at} when not is_nil(used_at) ->
+        {:error, :token_already_used}
+
+      token ->
+        if DateTime.compare(token.expires_at, DateTime.utc_now()) == :lt do
+          {:error, :token_expired}
+        else
+          create_device_from_token(token, device_name)
+        end
+    end
+  end
+
+  defp create_device_from_token(token, device_name) do
+    api_token = :crypto.strong_rand_bytes(32) |> Base.encode16(case: :lower)
+    api_token_hash = hash_token(api_token)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.transaction(fn ->
+      token
+      |> Ecto.Changeset.change(used_at: now)
+      |> Repo.update!()
+
+      device =
+        %Device{}
+        |> Device.changeset(%{name: device_name})
+        |> Ecto.Changeset.put_change(:api_token_hash, api_token_hash)
+        |> Ecto.Changeset.put_change(:organization_id, token.organization_id)
+        |> Ecto.Changeset.put_change(:provisioned_by_id, token.created_by_id)
+        |> Ecto.Changeset.put_change(:provisioned_at, now)
+        |> Repo.insert!()
+
+      %{device: device, api_token: api_token}
+    end)
+  end
+
+  def list_devices(organization_id) do
+    Device
+    |> where([d], d.organization_id == ^organization_id)
+    |> order_by([d], desc: d.provisioned_at)
+    |> preload(:provisioned_by)
+    |> Repo.all()
+  end
+
+  def get_device!(id), do: Repo.get!(Device, id)
+
+  def revoke_device(device_id) do
+    device = Repo.get!(Device, device_id)
+
+    device
+    |> Ecto.Changeset.change(status: "revoked")
+    |> Repo.update()
+  end
+
+  def authenticate_device(api_token) do
+    hash = hash_token(api_token)
+
+    case Repo.get_by(Device, api_token_hash: hash) do
+      nil ->
+        {:error, :invalid}
+
+      %{status: "revoked"} ->
+        {:error, :revoked}
+
+      device ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+        device |> Ecto.Changeset.change(last_seen_at: now) |> Repo.update()
+    end
+  end
+
+  defp generate_short_code do
+    part = fn ->
+      :crypto.strong_rand_bytes(2)
+      |> Base.encode32(case: :upper, padding: false)
+      |> String.slice(0, 4)
+    end
+
+    "#{part.()}-#{part.()}"
+  end
+end

--- a/pretex/lib/pretex/devices/device.ex
+++ b/pretex/lib/pretex/devices/device.ex
@@ -1,0 +1,27 @@
+defmodule Pretex.Devices.Device do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @statuses ~w(active revoked)
+
+  schema "devices" do
+    field(:name, :string)
+    field(:api_token_hash, :string)
+    field(:status, :string, default: "active")
+    field(:last_seen_at, :utc_datetime)
+    field(:provisioned_at, :utc_datetime)
+
+    belongs_to(:organization, Pretex.Organizations.Organization)
+    belongs_to(:provisioned_by, Pretex.Accounts.User, foreign_key: :provisioned_by_id)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(device, attrs) do
+    device
+    |> cast(attrs, [:name, :status, :last_seen_at])
+    |> validate_required([:name])
+    |> validate_length(:name, min: 1, max: 255)
+    |> validate_inclusion(:status, @statuses)
+  end
+end

--- a/pretex/lib/pretex/devices/device_init_token.ex
+++ b/pretex/lib/pretex/devices/device_init_token.ex
@@ -1,0 +1,21 @@
+defmodule Pretex.Devices.DeviceInitToken do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "device_init_tokens" do
+    field(:token_hash, :string)
+    field(:expires_at, :utc_datetime)
+    field(:used_at, :utc_datetime)
+
+    belongs_to(:organization, Pretex.Organizations.Organization)
+    belongs_to(:created_by, Pretex.Accounts.User, foreign_key: :created_by_id)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(token, attrs) do
+    token
+    |> cast(attrs, [:expires_at, :used_at])
+    |> validate_required([:expires_at])
+  end
+end

--- a/pretex/lib/pretex_web/components/dashboard.ex
+++ b/pretex/lib/pretex_web/components/dashboard.ex
@@ -66,6 +66,11 @@ defmodule PretexWeb.Components.Dashboard do
         label: "Associações",
         path: "/admin/organizations/#{org_id}/memberships"
       },
+      %{
+        icon: "hero-device-phone-mobile",
+        label: "Dispositivos",
+        path: "/admin/organizations/#{org_id}/devices"
+      },
       %{icon: "hero-chart-bar", label: "Relatórios", path: "#", disabled: true},
       %{icon: "hero-cog-6-tooth", label: "Configurações", path: "#", disabled: true}
     ]

--- a/pretex/lib/pretex_web/controllers/device_controller.ex
+++ b/pretex/lib/pretex_web/controllers/device_controller.ex
@@ -1,0 +1,35 @@
+defmodule PretexWeb.DeviceController do
+  use PretexWeb, :controller
+
+  alias Pretex.Devices
+
+  def provision(conn, %{"token" => token, "device_name" => device_name}) do
+    case Devices.provision_device(token, device_name) do
+      {:ok, %{device: device, api_token: api_token}} ->
+        device = Pretex.Repo.preload(device, :organization)
+
+        conn
+        |> put_status(:created)
+        |> json(%{
+          device_id: device.id,
+          api_token: api_token,
+          organization_name: device.organization.name
+        })
+
+      {:error, :invalid_token} ->
+        conn |> put_status(:not_found) |> json(%{error: "Token inválido"})
+
+      {:error, :token_expired} ->
+        conn |> put_status(:gone) |> json(%{error: "Token expirado"})
+
+      {:error, :token_already_used} ->
+        conn |> put_status(:conflict) |> json(%{error: "Token já utilizado"})
+    end
+  end
+
+  def provision(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "Parâmetros token e device_name são obrigatórios"})
+  end
+end

--- a/pretex/lib/pretex_web/live/admin/device_live/index.ex
+++ b/pretex/lib/pretex_web/live/admin/device_live/index.ex
@@ -1,0 +1,69 @@
+defmodule PretexWeb.Admin.DeviceLive.Index do
+  use PretexWeb, :live_view
+
+  alias Pretex.Devices
+  alias Pretex.Organizations
+
+  @impl true
+  def mount(%{"org_id" => org_id}, _session, socket) do
+    org = Organizations.get_organization!(org_id)
+    devices = Devices.list_devices(org.id)
+
+    socket =
+      socket
+      |> assign(:org, org)
+      |> assign(:devices, devices)
+      |> assign(:generated_token, nil)
+      |> assign(:page_title, "Dispositivos — #{org.name}")
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("generate_token", _, socket) do
+    org = socket.assigns.org
+    user_id = socket.assigns.current_user.id
+
+    case Devices.generate_init_token(org.id, user_id) do
+      {:ok, token_code} ->
+        {:noreply, assign(socket, :generated_token, token_code)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Erro ao gerar token.")}
+    end
+  end
+
+  @impl true
+  def handle_event("dismiss_token", _, socket) do
+    {:noreply, assign(socket, :generated_token, nil)}
+  end
+
+  @impl true
+  def handle_event("revoke_device", %{"id" => id_str}, socket) do
+    id = String.to_integer(id_str)
+
+    case Devices.revoke_device(id) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(:devices, Devices.list_devices(socket.assigns.org.id))
+         |> put_flash(:info, "Acesso do dispositivo revogado.")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Erro ao revogar dispositivo.")}
+    end
+  end
+
+  defp time_ago(nil), do: "Nunca"
+
+  defp time_ago(datetime) do
+    diff = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+    cond do
+      diff < 60 -> "há #{diff}s"
+      diff < 3600 -> "há #{div(diff, 60)}min"
+      diff < 86400 -> "há #{div(diff, 3600)}h"
+      true -> "há #{div(diff, 86400)}d"
+    end
+  end
+end

--- a/pretex/lib/pretex_web/live/admin/device_live/index.html.heex
+++ b/pretex/lib/pretex_web/live/admin/device_live/index.html.heex
@@ -1,0 +1,91 @@
+<.dashboard_layout
+  current_path={~p"/admin/organizations/#{@org}/devices"}
+  org={@org}
+  flash={@flash}
+>
+  <div class="mx-auto max-w-4xl px-4 py-8">
+    <div class="mb-6 flex items-center justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-base-content">Dispositivos</h1>
+        <p class="text-sm text-base-content/60 mt-1">{@org.name}</p>
+      </div>
+      <button phx-click="generate_token" class="btn btn-primary btn-sm gap-1">
+        <.icon name="hero-plus" class="size-4" /> Gerar Token
+      </button>
+    </div>
+
+    <%!-- Generated token display --%>
+    <div
+      :if={@generated_token}
+      class="mb-6 rounded-2xl border-2 border-primary/30 bg-primary/5 p-6 text-center"
+    >
+      <p class="text-xs font-semibold uppercase tracking-widest text-primary/70 mb-2">
+        Token de Inicialização
+      </p>
+      <p class="text-4xl font-mono font-bold tracking-[0.3em] text-primary mb-3">
+        {@generated_token}
+      </p>
+      <p class="text-sm text-base-content/60 mb-4">
+        Compartilhe este código com o voluntário. Ele expira em 24 horas e só pode ser usado uma vez.
+      </p>
+      <button phx-click="dismiss_token" class="btn btn-ghost btn-sm">
+        <.icon name="hero-x-mark" class="size-4" /> Fechar
+      </button>
+    </div>
+
+    <%!-- Devices table --%>
+    <div class="card bg-base-100 border border-base-200 shadow-sm">
+      <div :if={@devices == []} class="p-12 text-center">
+        <.icon name="hero-device-phone-mobile" class="size-12 text-base-content/20 mx-auto mb-3" />
+        <p class="text-sm text-base-content/50">Nenhum dispositivo provisionado.</p>
+        <p class="text-xs text-base-content/40 mt-1">
+          Gere um token de inicialização e compartilhe com um voluntário para provisionar um dispositivo.
+        </p>
+      </div>
+
+      <div
+        :for={device <- @devices}
+        class="flex items-center justify-between gap-4 px-5 py-4 border-b border-base-200 last:border-b-0"
+      >
+        <div class="flex items-center gap-3 min-w-0 flex-1">
+          <div class={[
+            "w-2.5 h-2.5 rounded-full shrink-0",
+            if(device.status == "active", do: "bg-success", else: "bg-error")
+          ]}>
+          </div>
+          <div class="min-w-0">
+            <p class="font-medium text-sm text-base-content truncate">{device.name}</p>
+            <p class="text-xs text-base-content/50">
+              Provisionado por {device.provisioned_by.name} ·
+              {Calendar.strftime(device.provisioned_at, "%d/%m/%Y %H:%M")}
+            </p>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-4 shrink-0">
+          <div class="text-right">
+            <p class="text-xs text-base-content/50">Última atividade</p>
+            <p class="text-sm text-base-content/70">{time_ago(device.last_seen_at)}</p>
+          </div>
+
+          <span class={[
+            "badge badge-sm",
+            if(device.status == "active", do: "badge-success", else: "badge-error")
+          ]}>
+            {if device.status == "active", do: "Ativo", else: "Revogado"}
+          </span>
+
+          <button
+            :if={device.status == "active"}
+            phx-click="revoke_device"
+            phx-value-id={device.id}
+            data-confirm={"Revogar acesso de \"#{device.name}\"? O dispositivo não poderá mais fazer check-in."}
+            class="btn btn-ghost btn-xs text-error"
+          >
+            Revogar
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</.dashboard_layout>

--- a/pretex/lib/pretex_web/router.ex
+++ b/pretex/lib/pretex_web/router.ex
@@ -203,6 +203,8 @@ defmodule PretexWeb.Router do
       live("/organizations/:org_id/memberships/new", MembershipLive.Index, :new)
       live("/organizations/:org_id/memberships/:id/edit", MembershipLive.Index, :edit)
       live("/organizations/:org_id/memberships/:id/grant", MembershipLive.Index, :grant)
+
+      live("/organizations/:org_id/devices", DeviceLive.Index, :index)
     end
   end
 

--- a/pretex/lib/pretex_web/router.ex
+++ b/pretex/lib/pretex_web/router.ex
@@ -41,6 +41,14 @@ defmodule PretexWeb.Router do
     post("/payments/:token", PaymentWebhookController, :receive)
   end
 
+  # -- Device provisioning API (no auth — init token is the auth) ---------------
+
+  scope "/api", PretexWeb do
+    pipe_through(:api)
+
+    post("/devices/provision", DeviceController, :provision)
+  end
+
   # -- Staff auth (magic link) -----------------------------------------------
 
   scope "/staff", PretexWeb do

--- a/pretex/priv/repo/migrations/20260323232908_create_devices.exs
+++ b/pretex/priv/repo/migrations/20260323232908_create_devices.exs
@@ -1,0 +1,33 @@
+defmodule Pretex.Repo.Migrations.CreateDevices do
+  use Ecto.Migration
+
+  def change do
+    create table(:device_init_tokens) do
+      add :token_hash, :string, null: false
+      add :organization_id, references(:organizations, on_delete: :delete_all), null: false
+      add :created_by_id, references(:users, on_delete: :restrict), null: false
+      add :expires_at, :utc_datetime, null: false
+      add :used_at, :utc_datetime
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:device_init_tokens, [:token_hash])
+    create index(:device_init_tokens, [:organization_id])
+
+    create table(:devices) do
+      add :name, :string, null: false
+      add :api_token_hash, :string, null: false
+      add :status, :string, null: false, default: "active"
+      add :last_seen_at, :utc_datetime
+      add :provisioned_at, :utc_datetime, null: false
+      add :organization_id, references(:organizations, on_delete: :delete_all), null: false
+      add :provisioned_by_id, references(:users, on_delete: :restrict), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:devices, [:api_token_hash])
+    create index(:devices, [:organization_id])
+  end
+end

--- a/pretex/test/pretex/devices_test.exs
+++ b/pretex/test/pretex/devices_test.exs
@@ -1,0 +1,156 @@
+defmodule Pretex.DevicesTest do
+  use Pretex.DataCase, async: true
+
+  import Pretex.OrganizationsFixtures
+  import Pretex.AccountsFixtures
+
+  alias Pretex.Devices
+  alias Pretex.Devices.Device
+
+  describe "generate_init_token/2" do
+    test "generates an 8-char token with dash format" do
+      org = org_fixture()
+      user = user_fixture()
+
+      assert {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+      assert String.match?(token_code, ~r/^[A-Z0-9]{4}-[A-Z0-9]{4}$/)
+    end
+
+    test "stores token hashed in the database" do
+      org = org_fixture()
+      user = user_fixture()
+
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+      hash = Devices.hash_token(token_code)
+
+      assert Pretex.Repo.get_by(Pretex.Devices.DeviceInitToken, token_hash: hash)
+    end
+  end
+
+  describe "provision_device/2" do
+    test "provisions a device with a valid token" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+
+      assert {:ok, %{device: %Device{} = device, api_token: api_token}} =
+               Devices.provision_device(token_code, "iPhone de João")
+
+      assert device.name == "iPhone de João"
+      assert device.organization_id == org.id
+      assert device.status == "active"
+      assert device.provisioned_at != nil
+      assert is_binary(api_token)
+    end
+
+    test "marks init token as used" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+
+      {:ok, _} = Devices.provision_device(token_code, "Device")
+
+      hash = Devices.hash_token(token_code)
+      token = Pretex.Repo.get_by!(Pretex.Devices.DeviceInitToken, token_hash: hash)
+      assert token.used_at != nil
+    end
+
+    test "rejects already-used token" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+
+      {:ok, _} = Devices.provision_device(token_code, "Device 1")
+
+      assert {:error, :token_already_used} =
+               Devices.provision_device(token_code, "Device 2")
+    end
+
+    test "rejects expired token" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+
+      hash = Devices.hash_token(token_code)
+      token = Pretex.Repo.get_by!(Pretex.Devices.DeviceInitToken, token_hash: hash)
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      token |> Ecto.Changeset.change(expires_at: past) |> Pretex.Repo.update!()
+
+      assert {:error, :token_expired} =
+               Devices.provision_device(token_code, "Device")
+    end
+
+    test "rejects invalid token" do
+      assert {:error, :invalid_token} =
+               Devices.provision_device("ZZZZ-ZZZZ", "Device")
+    end
+  end
+
+  describe "list_devices/1" do
+    test "returns devices for organization" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token1} = Devices.generate_init_token(org.id, user.id)
+      {:ok, token2} = Devices.generate_init_token(org.id, user.id)
+
+      {:ok, _} = Devices.provision_device(token1, "Device 1")
+      {:ok, _} = Devices.provision_device(token2, "Device 2")
+
+      devices = Devices.list_devices(org.id)
+      assert length(devices) == 2
+    end
+
+    test "does not return devices from other organizations" do
+      org1 = org_fixture()
+      org2 = org_fixture()
+      user = user_fixture()
+
+      {:ok, token} = Devices.generate_init_token(org1.id, user.id)
+      {:ok, _} = Devices.provision_device(token, "Device 1")
+
+      assert Devices.list_devices(org2.id) == []
+    end
+  end
+
+  describe "revoke_device/1" do
+    test "revokes an active device" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token} = Devices.generate_init_token(org.id, user.id)
+      {:ok, %{device: device}} = Devices.provision_device(token, "Device")
+
+      assert {:ok, revoked} = Devices.revoke_device(device.id)
+      assert revoked.status == "revoked"
+    end
+  end
+
+  describe "authenticate_device/1" do
+    test "authenticates with valid API token" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+      {:ok, %{api_token: api_token}} = Devices.provision_device(token_code, "Device")
+
+      assert {:ok, device} = Devices.authenticate_device(api_token)
+      assert device.status == "active"
+    end
+
+    test "rejects revoked device" do
+      org = org_fixture()
+      user = user_fixture()
+      {:ok, token_code} = Devices.generate_init_token(org.id, user.id)
+
+      {:ok, %{device: device, api_token: api_token}} =
+        Devices.provision_device(token_code, "Device")
+
+      {:ok, _} = Devices.revoke_device(device.id)
+
+      assert {:error, :revoked} = Devices.authenticate_device(api_token)
+    end
+
+    test "rejects invalid API token" do
+      assert {:error, :invalid} = Devices.authenticate_device("bogus-token")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements [Story 022: Device Provisioning](https://github.com/devsnorte/ingressos/issues/22) — allows organizers to provision check-in devices for volunteers via short initialization tokens.

- **Token generation** — organizers generate 8-char codes (XXXX-XXXX) with 24h expiry, single use
- **Device provisioning** — volunteers enter token to provision their phone, receive long-lived API token
- **Device management** — admin LiveView listing all devices with status, last seen, and revoke action
- **Revocation** — organizer revokes access with confirmation, device can no longer authenticate
- **Organization scoping** — devices belong to one org, can only access that org's data
- **Sidebar navigation** — "Dispositivos" entry in org-level admin sidebar
- **Provisioning API** — `POST /api/devices/provision` (no auth, token IS the auth)

### Files changed (9 files, ~450 lines)

| Area | Files |
|------|-------|
| **Database** | Migration: `devices` + `device_init_tokens` tables |
| **Schemas** | `Device`, `DeviceInitToken` |
| **Context** | `Pretex.Devices` — token gen, provisioning, auth, revocation |
| **API** | `DeviceController` — `POST /api/devices/provision` |
| **LiveView** | `DeviceLive.Index` — token display, device list, revoke |
| **Navigation** | Sidebar "Dispositivos" entry |
| **Tests** | 13 tests covering all provisioning scenarios |

Closes #22

## Test plan

- [x] All 1500 tests pass (0 failures)
- [x] Compilation clean with `--warnings-as-errors`
- [ ] Manual: Navigate to org sidebar → Dispositivos link visible
- [ ] Manual: Generate token → 8-char code displayed
- [ ] Manual: `curl -X POST /api/devices/provision -d '{"token":"XXXX-XXXX","device_name":"Test"}'` → returns API token
- [ ] Manual: Device appears in list after provisioning
- [ ] Manual: Revoke device → status changes to "Revogado"
- [ ] Manual: Same token cannot be reused